### PR TITLE
return sqlalchemy query objects directly

### DIFF
--- a/test/test_psqlgraph.py
+++ b/test/test_psqlgraph.py
@@ -111,8 +111,15 @@ class TestPsqlGraphDriver(unittest.TestCase):
         nodes = list(self.driver.node_lookup(
             node_id=node_id,
             property_matches=matches,
-            include_voided=voided
+            voided=False
         ))
+        if voided:
+            voided_nodes = list(self.driver.node_lookup(
+                node_id=node_id,
+                property_matches=matches,
+                voided=True
+            ))
+            nodes = list(nodes) + list(voided_nodes)
         length = len(nodes)
         self.assertEqual(length, count, 'Expected a {n} nodes to '
                          'be found, instead found {count}'.format(

--- a/test/test_psqlgraph2neoj4.py
+++ b/test/test_psqlgraph2neoj4.py
@@ -105,7 +105,11 @@ class Test_psql2neo(unittest.TestCase):
         return n
         """.format(src_id=src_id, dst_id=dst_id))
         self.assertEqual(len(nodes), 1)
-        edges = self.neo4jDriver.cypher.execute('match (n)-[r]->(m) return r')
+        edges = self.neo4jDriver.cypher.execute("""
+        match (n)-[r]-(m)
+        where n.id = "{dst_id}" and m.id = "{src_id}"
+        return r
+        """.format(src_id=src_id, dst_id=dst_id))
         self.assertEqual(len(edges), 1)
 
     def test_neo_star_topology(self):


### PR DESCRIPTION
rather than wrapping them in our own generators. This makes things more composable because clients can now use the results of these methods in other sqlalchemy operations e.g. [subqueries](http://docs.sqlalchemy.org/en/rel_0_9/orm/query.html?highlight=subquery#sqlalchemy.orm.query.Query.subquery), [unions](http://docs.sqlalchemy.org/en/rel_0_9/orm/query.html?highlight=first#sqlalchemy.orm.query.Query.union)

r? @millerjs 
