### PR TITLE
fix session misuse

### DIFF
--- a/psqlgraph/node.py
+++ b/psqlgraph/node.py
@@ -3,6 +3,7 @@ from sqlalchemy.dialects.postgres import ARRAY, JSONB
 from sqlalchemy import Column, Integer, Text, DateTime
 from sqlalchemy.orm import relationship
 from datetime import datetime
+import copy
 
 from sanitizer import sanitize
 from psqlgraph import Base
@@ -121,14 +122,15 @@ class PsqlNode(Base):
         """
 
         if system_annotations:
-            self.syste_annotations = self.system_annotations.update(
-                sanitize(system_annotations))
+            self.system_annotations = copy.deepcopy(self.system_annotations)
+            self.system_annotations.update(sanitize(system_annotations))
 
         if properties:
-            properties = sanitize(properties)
-            self.properties.update(properties)
+            self.properties = copy.deepcopy(self.properties)
+            self.properties.update(sanitize(properties))
 
         if acl:
+            self.acl = copy.deepcopy(self.acl)
             self.acl += acl
 
 

--- a/psqlgraph/psqlgraph.py
+++ b/psqlgraph/psqlgraph.py
@@ -205,8 +205,7 @@ class PsqlGraphDriver(object):
                     acl=acl,
                     properties=properties,
                 ), session=local)
-
-            return node
+        return node
 
     def node_insert(self, node, session=None):
         """Takes a PsqlNode and inserts it into the graph.


### PR DESCRIPTION
@millerjs similar bug to last time: `session` was being passed instead of `local`, which resulted in superfluous sessions being created (since `session` is sometimes `None`, so it would create a new one). The deepcopying in `merge` seems to be necessary in order to get it to actually update things in the database, there's probably some sort of object identity check happening under the hood that prevents mutating from working.
