### PR TITLE
fix acl merging

### DIFF
--- a/psqlgraph/node.py
+++ b/psqlgraph/node.py
@@ -102,7 +102,7 @@ class PsqlNode(Base):
             for subsrc in edge_in.src.walk_backward():
                 yield subsrc
 
-    def merge(self, acl=[], system_annotations={}, properties={}):
+    def merge(self, acl=None, system_annotations={}, properties={}):
         """Merges a new node onto this instance.  The parameter ``node``
         should contain the 'new' values with the following effects. In
         general, updates are additive. New properties will be added to
@@ -131,7 +131,7 @@ class PsqlNode(Base):
             self.properties = copy.deepcopy(self.properties)
             self.properties.update(sanitize(properties))
 
-        if acl:
+        if acl is not None:
             self.acl = acl
 
 

--- a/psqlgraph/psqlgraph.py
+++ b/psqlgraph/psqlgraph.py
@@ -195,7 +195,7 @@ class PsqlGraphDriver(object):
         return query.one()[0]
 
     @retryable
-    def node_merge(self, node_id=None, node=None, acl=[],
+    def node_merge(self, node_id=None, node=None, acl=None,
                    label=None, system_annotations={}, properties={},
                    session=None, max_retries=DEFAULT_RETRIES,
                    backoff=default_backoff):
@@ -336,7 +336,7 @@ class PsqlGraphDriver(object):
         return node
 
     def node_update(self, node, system_annotations={},
-                    acl=[], properties={}, session=None):
+                    acl=None, properties={}, session=None):
         """
         This function assumes that you have already done a query for an
         existing node!  This function will take an node, void it and

--- a/test/test_psqlgraph.py
+++ b/test/test_psqlgraph.py
@@ -172,6 +172,19 @@ class TestPsqlGraphDriver(unittest.TestCase):
         node = self.driver.node_lookup_one(tempid)
         self.assertEqual(sanitize(properties), node.properties)
 
+    def test_node_update_updates_acls(self):
+        tempid = str(uuid.uuid4())
+        with self.driver.session_scope():
+            node = self.driver.node_merge(node_id=tempid, label='test')
+            self.driver.node_update(node, acl=["somebody"])
+        with self.driver.session_scope():
+            node = self.driver.nodes().ids([tempid]).one()
+            self.assertEqual(node.acl, ["somebody"])
+        self.driver.node_merge(node_id=node.node_id, acl=[])
+        with self.driver.session_scope():
+            node = self.driver.nodes().ids([tempid]).one()
+            self.assertEqual(node.acl, [])
+
     def test_node_update_properties_by_id(self, given_id=None, label=None):
         """Test updating node properties by ID
 


### PR DESCRIPTION
r? @millerjs 

acl "merging" should really replace rather than append; otherwise there's no way to remove acls (as I learned the hard way in the dcc sync code :P)

we should probably add some tests before merging, I just needed to get it working for the dcc import
