### PR TITLE
Strip host from conn string when host is None

### DIFF
--- a/psqlgraph/psqlgraph.py
+++ b/psqlgraph/psqlgraph.py
@@ -29,8 +29,9 @@ class PsqlGraphDriver(object):
     def __init__(self, host, user, password, database, **kwargs):
         kwargs.pop('node_validator', None)
         kwargs.pop('edge_validator', None)
+        host = '' if host is None else host
         conn_str = 'postgresql://{user}:{password}@{host}/{database}'.format(
-            user=user, password=password, host=host if host else '', database=database)
+            user=user, password=password, host=host, database=database)
         if 'isolation_level' not in kwargs:
             kwargs['isolation_level'] = 'REPEATABLE_READ'
         if kwargs['isolation_level'] not in self.acceptable_isolation_levels:


### PR DESCRIPTION
This is needed so it works on PO internal Postgres setup, I think it would be generally useful...

Per http://docs.sqlalchemy.org/en/latest/dialects/postgresql.html#unix-domain-connections,
need to remove host spec completely to get psycopg2 to know to use a unix socket rather
than a http endpoint. Old version of code stringifies None, and blithely submits
...//user:password@None/dbname. New version just removes 'None' to give
...//user:password@/dbname, which works.
