### PR TITLE
relax requests version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,6 @@ setup(
         'progressbar',
         'avro==1.7.7',
         'xlocal==0.5',
-        'requests==2.5.1'
+        'requests>=2.5.2, <2.6.0'
     ]
 )


### PR DESCRIPTION
This relaxes the requests version we require. The ultimate reason for this is that zugs needs to depend on docker-py, which requires requests >=2.5.2. We probably shouldn't be pinning versions so hard in something intended to be used as a library anyway.

r? @millerjs 
