### PR TITLE
fix(psql2neo): Add double escape for special characters

### DIFF
--- a/psqlgraph/psqlgraph2neo4j.py
+++ b/psqlgraph/psqlgraph2neo4j.py
@@ -76,8 +76,8 @@ class PsqlGraph2Neo4j(object):
         result = id+'\t'+node.node_id + '\t' + node.label + '\t'
         for key in node_file[1]:
             value = unicode(node.properties.get(key, ''))\
-                .replace('\r', '\\r').replace('\n', '\\n')\
-                .replace('"', "'")
+                .replace('\r', '\\\\r').replace('\n', '\\\\n')\
+                .replace('"', '\\"')
             if value == 'None':
                 value = ''
             result += value+'\t'


### PR DESCRIPTION
This fixes the issue with \n and \r not being preserved. The `\\\\r` write to csv file as `\\r` and then batch importer convert it to `\r`...
r? @millerjs 
@BedfordWest Tested in qa environment, \n and \r are represented the same as in psqlgraph now.
