### PR TITLE
fix(sysan): sanitize when setting keys

### DIFF
--- a/psqlgraph/attributes.py
+++ b/psqlgraph/attributes.py
@@ -27,7 +27,7 @@ class SystemAnnotationDict(dict):
     def __setitem__(self, key, val):
         temp = dict(self.source._sysan)
         temp[key] = val
-        self.source._sysan = temp
+        self.source.system_annotations = temp
         super(SystemAnnotationDict, self).__setitem__(key, val)
 
     def __delitem__(self, key):

--- a/test/test_psqlgraph2.py
+++ b/test/test_psqlgraph2.py
@@ -332,3 +332,14 @@ class TestPsqlGraphDriver(unittest.TestCase):
             nodes = g.nodes()
         with self.assertRaises(SessionClosedError):
             nodes.first()
+
+    def test_sysan_sanitization(self):
+        """It shouldn't be possible to set system annotations keys to
+        anything but primitive values.
+
+        """
+        a = Test(str(uuid.uuid4()))
+        with g.session_scope() as s:
+            a = s.merge(a)
+            with self.assertRaises(ValueError):
+                a.sysan["foo"] = {"bar": "baz"}


### PR DESCRIPTION
r? @millerjs 

This fixes an issue where system_annotations keys wouldn't be sanitized when setting them directly, as well as adding a test for same.
