### PR TITLE
fix(hooks): only hook on nodes and edges

### DIFF
--- a/psqlgraph/hooks.py
+++ b/psqlgraph/hooks.py
@@ -49,6 +49,12 @@ def receive_before_flush(session, flush_context, instances):
 
     """
     for target in session.dirty:
+
+        # Only hook on Nodes and Edges
+        if target.__class__ not in (
+                Node.__subclasses__()+Edge.__subclasses__()):
+            continue
+
         target._validate()
         props, sysan = get_old_version(target, 'unchanged', 'deleted')
         props_diff, sysan_diff = get_old_version(target, 'deleted', 'added')


### PR DESCRIPTION
Currently a psqlgraph session attaches hooks to flush.  

This PR adds skip of the flush hook in order to use this session to flush entities that are not subclasses of Node and Edge.
