### PR TITLE
feat(timestamp): add flush timestamp

### DIFF
--- a/psqlgraph/hooks.py
+++ b/psqlgraph/hooks.py
@@ -48,6 +48,11 @@ def receive_before_flush(session, flush_context, instances):
     - Merge deleted props/sysan on top of that
 
     """
+
+    if session._set_flush_timestamps:
+        session._flush_timestamp = list(
+            session.execute("SELECT CURRENT_TIMESTAMP"))[0][0]
+
     for target in session.dirty:
 
         # Only hook on Nodes and Edges

--- a/psqlgraph/psqlgraph.py
+++ b/psqlgraph/psqlgraph.py
@@ -28,6 +28,15 @@ class PsqlGraphDriver(object):
     acceptable_isolation_levels = ['REPEATABLE_READ', 'SERIALIZABLE']
 
     def __init__(self, host, user, password, database, **kwargs):
+        """Create a Postgresql Graph Driver
+
+        :param bool set_flush_timestamps:
+            Is `True` by default.  Setting this to `True` will
+            perform an extra database query to get the server time at
+            flush and store `session._flush_timestamp`.
+
+        """
+        self.set_flush_timestamps = kwargs.pop('set_flush_timestamps', True)
         kwargs.pop('node_validator', None)
         kwargs.pop('edge_validator', None)
         host = '' if host is None else host
@@ -50,6 +59,8 @@ class PsqlGraphDriver(object):
         Session = sessionmaker(expire_on_commit=False, class_=GraphSession)
         Session.configure(bind=self.engine, query_cls=GraphQuery)
         session = Session()
+        session._flush_timestamp = None
+        session._set_flush_timestamps = self.set_flush_timestamps
         event.listen(session, 'before_flush', receive_before_flush)
         return session
 

--- a/test/test_psqlgraph2.py
+++ b/test/test_psqlgraph2.py
@@ -327,8 +327,7 @@ class TestPsqlGraphDriver(unittest.TestCase):
             a = s.merge(a)
 
     def test_session_closing(self):
-        a = Test(str(uuid.uuid4()))
-        with g.session_scope() as s:
+        with g.session_scope():
             nodes = g.nodes()
         with self.assertRaises(SessionClosedError):
             nodes.first()
@@ -343,3 +342,15 @@ class TestPsqlGraphDriver(unittest.TestCase):
             a = s.merge(a)
             with self.assertRaises(ValueError):
                 a.sysan["foo"] = {"bar": "baz"}
+
+    def test_session_timestamp(self):
+        with g.session_scope() as s:
+            self.assertIsNone(s._flush_timestamp)
+            s.merge(Test(""))
+            s.flush()
+            self.assertIsNotNone(s._flush_timestamp)
+        g.set_flush_timestamps = False
+        with g.session_scope() as s:
+            s.merge(Test(""))
+            s.flush()
+            self.assertIsNone(s._flush_timestamp)


### PR DESCRIPTION
Timestamps a session based on it's last flush.  This is useful to share a conveniently placed server time for mapper hooks (like created/updated datetime JSONB properties).

r? @porterjamesj @philloooo 
