### PR TITLE
feat(app_name): Add customizable application_name

### DIFF
--- a/psqlgraph/psqlgraph.py
+++ b/psqlgraph/psqlgraph.py
@@ -19,6 +19,7 @@ from voided_edge import VoidedEdge
 from voided_node import VoidedNode
 from session import GraphSession
 import psqlgraph2neo4j
+import socket
 
 DEFAULT_RETRIES = 0
 
@@ -36,14 +37,23 @@ class PsqlGraphDriver(object):
             flush and store `session._flush_timestamp`.
 
         """
-        self.set_flush_timestamps = kwargs.pop('set_flush_timestamps', True)
+
+        # Parse kwargs
+        connect_args = {}
         kwargs.pop('node_validator', None)
         kwargs.pop('edge_validator', None)
+        self.set_flush_timestamps = kwargs.pop('set_flush_timestamps', True)
+        if 'isolation_level' not in kwargs:
+            kwargs['isolation_level'] = 'REPEATABLE_READ'
+        if 'application_name' in kwargs:
+            connect_args['application_name'] = kwargs.pop('application_name')
+        else:
+            connect_args['application_name'] = socket.gethostname()
+
+        # Construct connection string
         host = '' if host is None else host
         conn_str = 'postgresql://{user}:{password}@{host}/{database}'.format(
             user=user, password=password, host=host, database=database)
-        if 'isolation_level' not in kwargs:
-            kwargs['isolation_level'] = 'REPEATABLE_READ'
         if kwargs['isolation_level'] not in self.acceptable_isolation_levels:
             logging.warn((
                 "Using an isolation level '{}' that is not in the list of "
@@ -52,7 +62,16 @@ class PsqlGraphDriver(object):
                 "the commit of a concurrent session and losing data!"
             ).format(
                 kwargs['isolation_level'], self.acceptable_isolation_levels))
-        self.engine = create_engine(conn_str, encoding='latin1', **kwargs)
+
+        # Create driver engine
+        self.engine = create_engine(
+            conn_str,
+            encoding='latin1',
+            connect_args=connect_args,
+            **kwargs
+        )
+
+        # Create context for xlocal sessions
         self.context = xlocal()
 
     def _new_session(self):


### PR DESCRIPTION
- Adds application_name to engine creation
- Defaults to current hostname
- Allows database admin to trace owners of db processes
- Is customizable py passing `application_name` to driver init
