### PR TITLE
fix(property-list): add hybrid property switch

### DIFF
--- a/psqlgraph/base.py
+++ b/psqlgraph/base.py
@@ -159,9 +159,12 @@ class CommonBase(object):
         """Returns a list of hybrid_properties defined on the subclass model
 
         """
-        return [attr for attr in dir(cls)
-                if attr in cls.__dict__
-                and isinstance(cls.__dict__[attr], hybrid_property)]
+        return [
+            attr for attr in dir(cls)
+            if attr in cls.__dict__
+            and isinstance(cls.__dict__[attr], hybrid_property)
+            and getattr(getattr(cls, attr), '_is_pg_property', True)
+        ]
 
     @classmethod
     def has_property(cls, key):


### PR DESCRIPTION
- Adds 'is_pg_property' check to hybrid properties so you can use
  hybrid properties on nodes without having them pulled in as JSONB
  properties.
