### PR TITLE
feat(custom_hooks): add lists of callable custom hooks

### DIFF
--- a/psqlgraph/base.py
+++ b/psqlgraph/base.py
@@ -16,6 +16,10 @@ EDGE_TABLENAME_SCHEME = 'edge_{class_name}'
 
 class CommonBase(object):
 
+    _session_hooks_before_insert = []
+    _session_hooks_before_update = []
+    _session_hooks_before_delete = []
+
     # ======== Columns ========
     created = Column(
         DateTime(timezone=True),

--- a/psqlgraph/hooks.py
+++ b/psqlgraph/hooks.py
@@ -71,13 +71,29 @@ def receive_before_flush(session, flush_context, instances):
         if props_diff or sysan_diff:
             target._snapshot_existing(session, props, sysan)
         target._merge_onto_existing(props, sysan)
+
+        # Call custom session hook
+        for f in target._session_hooks_before_update:
+            f(target, session, flush_context, instances)
+
     for target in session.deleted:
         if not is_psqlgraph_entity(target):
             continue
+
         props, sysan = get_old_version(target, 'unchanged', 'deleted', 'added')
         target._snapshot_existing(session, props, sysan)
+
+        # Call custom session hook
+        for f in target._session_hooks_before_delete:
+            f(target, session, flush_context, instances)
+
     for target in session.new:
         if not is_psqlgraph_entity(target):
             continue
+
         if isinstance(target, (Node, Edge)):
             target._validate()
+
+        # Call custom session hook
+        for f in target._session_hooks_before_insert:
+            f(target, session, flush_context, instances)

--- a/psqlgraph/session.py
+++ b/psqlgraph/session.py
@@ -17,28 +17,28 @@ class GraphSession(Session):
 
     @inherit_docstring_from(Session)
     def __init__(self, *args, **kwargs):
-        
+
         self._psqlgraph_closed = False
-        
+
         return super(GraphSession, self).__init__(*args, **kwargs)
 
     @inherit_docstring_from(Session)
     def connection(self, *args, **kwargs):
-        
+
         if self._psqlgraph_closed:
             raise exc.SessionClosedError('session closed')
-        
+
         return super(GraphSession, self).connection(*args, **kwargs)
 
     def close(self, *args, **kwargs):
         """Close this Session.
-        
+
         This clears all items and ends any transaction in progress.
-        
+
         This also closes and prevents any new connections from being opened.
-        
+
         """
-        
+
         self._psqlgraph_closed = True
-        
+
         return super(GraphSession, self).close(*args, **kwargs)


### PR DESCRIPTION
Adds a place to inject custom pre-flush hooks for insertion, update, and deletion.

This feature will be used to propagate relationship caches as new edges are added.  The reason this cannot simply be a mapper hook on edge types (and therefore pushed to consuming code) is described [here](http://docs.sqlalchemy.org/en/latest/orm/events.html#sqlalchemy.orm.events.MapperEvents.before_insert), specifically

> ...Mapper-level flush events only allow very limited operations, on attributes local to the row being operated upon...

If we were to hook on edge types, then we would not be able to modify the source and destination because those are rows that probably have not been added to the session.   If we were to hook on those nodes themselves, then we would miss information about changing relationships.

This feature is intended to be generic here, in the base `psqlgraph` library, with consumer consuming code injecting hooks.

r? @NCI-GDC/ucdevs 
