### PR TITLE
fix(driver): allow user connect args

### DIFF
--- a/psqlgraph/psqlgraph.py
+++ b/psqlgraph/psqlgraph.py
@@ -39,7 +39,7 @@ class PsqlGraphDriver(object):
         """
 
         # Parse kwargs
-        connect_args = {}
+        connect_args = kwargs.pop('connect_args', {})
         kwargs.pop('node_validator', None)
         kwargs.pop('edge_validator', None)
         self.set_flush_timestamps = kwargs.pop('set_flush_timestamps', True)


### PR DESCRIPTION
allow user specified connect args for things like `{'sslmode': 'require'}`

r? @NCI-GDC/ucdevs 
