### PR TITLE
Feat/uuid node ids

### DIFF
--- a/psqlgraph/base.py
+++ b/psqlgraph/base.py
@@ -1,6 +1,6 @@
 from attributes import PropertiesDict, SystemAnnotationDict
 from sqlalchemy import Column, Text, DateTime, text, event
-from sqlalchemy.dialects.postgres import ARRAY, JSONB
+from sqlalchemy.dialects.postgres import ARRAY, JSONB, UUID
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -12,6 +12,9 @@ from util import sanitize, validate
 abstract_classes = ['Node', 'Edge', 'Base']
 NODE_TABLENAME_SCHEME = 'node_{class_name}'
 EDGE_TABLENAME_SCHEME = 'edge_{class_name}'
+
+#: The column type of ``node_id``, UUID treated as a string
+NODE_ID_TYPE = UUID(as_uuid=False)
 
 
 class CommonBase(object):

--- a/psqlgraph/edge.py
+++ b/psqlgraph/edge.py
@@ -1,15 +1,20 @@
-from sqlalchemy import Column, Text, ForeignKey, Index
+from sqlalchemy import Column, ForeignKey, Index
 from sqlalchemy.ext.declarative import AbstractConcreteBase, declared_attr
 from sqlalchemy.orm import relationship
 from sqlalchemy.ext.hybrid import hybrid_property
-
-from base import ORMBase, EDGE_TABLENAME_SCHEME, NODE_TABLENAME_SCHEME
 from voided_edge import VoidedEdge
+
+from base import (
+    EDGE_TABLENAME_SCHEME,
+    NODE_ID_TYPE,
+    NODE_TABLENAME_SCHEME,
+    ORMBase,
+)
 
 
 def IDColumn(tablename):
     return Column(
-        Text,
+        NODE_ID_TYPE,
         ForeignKey(
             '{}.node_id'.format(tablename),
             ondelete="CASCADE",

--- a/psqlgraph/migrations/alter_column_node_id_type_uuid.py
+++ b/psqlgraph/migrations/alter_column_node_id_type_uuid.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+"""
+migrations.alter_column_node_id_type_uuid
+----------------------------------
+
+Migrates up/down between states
+A: {node}.node_id is of type Text
+B: {node}.node_id is of type UUID
+"""
+
+from psqlgraph import Node, Edge
+
+import logging
+
+from edge_fk_constraint_utils import (
+    add_all_edge_fk_constraints,
+    drop_all_edge_fk_constraints,
+)
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+def node_up(connection, node):
+    logger.info('Migrating node {} up'.format(node))
+
+    connection.execute("""
+    ALTER TABLE {table} ALTER COLUMN node_id TYPE uuid USING node_id::uuid
+    """.format(
+        table=node.__tablename__,
+    ))
+
+
+def node_down(connection, node):
+    logger.info('Migrating node {} down'.format(node))
+
+    connection.execute("""
+    ALTER TABLE {table} ALTER COLUMN node_id TYPE TEXT
+    """.format(
+        table=node.__tablename__,
+    ))
+
+
+def edge_up(connection, edge):
+    logger.info('Migrating edge {} up'.format(edge))
+
+    for column in 'src_id', 'dst_id':
+        connection.execute("""
+        ALTER TABLE {table}
+        ALTER COLUMN {column} TYPE uuid USING {column}::uuid
+        """.format(
+            table=edge.__tablename__,
+            column=column,
+        ))
+
+
+def edge_down(connection, edge):
+    logger.info('Migrating edge {} down'.format(edge))
+
+    for column in 'src_id', 'dst_id':
+        connection.execute("""
+        ALTER TABLE {table} ALTER COLUMN {column} TYPE text
+        """.format(
+            table=edge.__tablename__,
+            column=column,
+        ))
+
+
+def up(connection):
+    transaction = connection.begin()
+
+    try:
+        drop_all_edge_fk_constraints(connection)
+        [node_up(connection, cls) for cls in Node.__subclasses__()]
+        [edge_up(connection, cls) for cls in Edge.__subclasses__()]
+        add_all_edge_fk_constraints(connection)
+        transaction.commit()
+
+    except Exception as e:
+        print(e)
+        transaction.rollback()
+        raise

--- a/psqlgraph/migrations/edge_fk_constraint_utils.py
+++ b/psqlgraph/migrations/edge_fk_constraint_utils.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+"""
+migrations.edge_fk_constraint_utils.py
+----------------------------------
+
+Adds and removes foreign key constraints to edge tables (doesn't
+remove or create edges).
+
+"""
+
+
+from psqlgraph import Node, Edge
+from sqlalchemy import text
+
+import logging
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+def constraint_exists(connection, constraint_name):
+    """Check if constraint exists"""
+
+    return any(connection.execute(
+        text("select 1 from pg_constraint where conname = :name"),
+        name=constraint_name
+    ))
+
+
+def get_fk_name(edge_table, column):
+    return "{edge_table}_{column}_fkey".format(
+        edge_table=edge_table,
+        column=column,
+    )
+
+
+def drop_edge_fk_constraint(connection, edge, column):
+    """Drop the edge constraint for a given edge column (src_id or dst_id)"""
+
+    fk_name = get_fk_name(edge.__tablename__, column)
+
+    if not constraint_exists(connection, fk_name):
+        return logger.info('Constraint %s does not exists', fk_name)
+
+    connection.execute(
+        "ALTER TABLE {table} DROP CONSTRAINT {fk_name}"
+        .format(table=edge.__tablename__, fk_name=fk_name)
+    )
+
+    logger.info('Dropped constraint %s', fk_name)
+
+
+def drop_edge_fk_constraints(connection, edge):
+    """Drop both edge constraints for a given edge"""
+
+    drop_edge_fk_constraint(connection, edge, 'src_id')
+    drop_edge_fk_constraint(connection, edge, 'dst_id')
+
+
+def add_edge_fk_constraint(connection, edge_table, column, neighbor_node):
+    """Creates fk constraint for edge in given column and neighbor"""
+
+    fk_name = get_fk_name(edge_table, column)
+
+    if constraint_exists(connection, fk_name):
+        return logger.info('Constraint %s already exists', fk_name)
+
+    connection.execute("""
+    ALTER TABLE {edge_table}
+      ADD CONSTRAINT "{fk_name}"
+      FOREIGN KEY ({column}) REFERENCES {node_table}(node_id)
+      ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED
+    """.format(
+        fk_name=fk_name,
+        edge_table=edge_table,
+        column=column,
+        node_table=neighbor_node.__tablename__,
+    ))
+
+    logger.info('Constraint %s created', fk_name)
+
+
+def add_edge_fk_constraints(connection, edge):
+    """Creates all fk constraints for edge"""
+
+    src_cls = Node.get_subclass_named(edge.__src_class__)
+    dst_cls = Node.get_subclass_named(edge.__dst_class__)
+
+    add_edge_fk_constraint(
+        connection,
+        edge.__tablename__,
+        'src_id',
+        src_cls,
+    )
+
+    add_edge_fk_constraint(
+        connection,
+        edge.__tablename__,
+        'dst_id',
+        dst_cls,
+    )
+
+
+def drop_all_edge_fk_constraints(connection):
+    """Deletes all fk constraints for all edges"""
+
+    for edge in Edge.__subclasses__():
+        drop_edge_fk_constraints(connection, edge)
+
+
+def add_all_edge_fk_constraints(connection):
+    """Creates all fk constraints for all edges"""
+
+    for edge in Edge.__subclasses__():
+        add_edge_fk_constraints(connection, edge)

--- a/psqlgraph/node.py
+++ b/psqlgraph/node.py
@@ -1,6 +1,6 @@
-from base import ORMBase, NODE_TABLENAME_SCHEME
+from base import ORMBase, NODE_TABLENAME_SCHEME, NODE_ID_TYPE
 from edge import Edge
-from sqlalchemy import Column, Text, UniqueConstraint, Index
+from sqlalchemy import Column, UniqueConstraint, Index
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.declarative import AbstractConcreteBase, declared_attr
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -29,7 +29,7 @@ class Node(AbstractConcreteBase, ORMBase):
         return list()
 
     node_id = Column(
-        Text,
+        NODE_ID_TYPE,
         primary_key=True,
         nullable=False,
     )

--- a/psqlgraph/psqlgraph.py
+++ b/psqlgraph/psqlgraph.py
@@ -263,8 +263,10 @@ class PsqlGraphDriver(object):
                    label=None, system_annotations={}, properties={},
                    session=None, max_retries=DEFAULT_RETRIES,
                    backoff=default_backoff):
+
         with self.session_scope() as local:
             if not node and not label:
+                assert node_id, 'node_id cannot be None'
                 node = self.nodes().ids(node_id).scalar()
 
             elif not node and label:

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -4,6 +4,10 @@ import uuid
 from psqlgraph import Node, Edge, PsqlGraphDriver
 from psqlgraph import PolyNode, PolyEdge
 
+from models import Test, Foo, Edge1, Edge2, Edge3
+from test_psqlgraph2 import uuid_hash
+
+
 host = 'localhost'
 user = 'test'
 password = 'test'
@@ -11,8 +15,6 @@ database = 'automated_test'
 g = PsqlGraphDriver(host, user, password, database)
 
 logging.basicConfig(level=logging.INFO)
-
-from models import Test, Foo, Edge1, Edge2, Edge3
 
 
 class TestPsqlGraphDriver(unittest.TestCase):
@@ -146,8 +148,9 @@ class TestPsqlGraphDriver(unittest.TestCase):
 
     def test_subq_without_path_filter(self):
         with self.g.session_scope():
+            node_id = uuid_hash('test')
             self.assertEqual(self.g.nodes(Foo)
                              .subq_without_path(
                                  'tests',
-                                 [lambda q: q.ids('test')])
+                                 [lambda q: q.ids(node_id)])
                              .count(), self.g.nodes(Foo).count())


### PR DESCRIPTION
Initial pass at [DAT-17](https://jira.opensciencedatacloud.org/browse/DAT-17).
- alters column type for `node_id` to `uuid`.
- provides up/down migrations to move from `text` to `uuid` and back
- updates tests to exclusively use uuids

See [DAT-17](https://jira.opensciencedatacloud.org/browse/DAT-17) for details.

Alternatively, there is There is an [existing branch](https://github.com/NCI-GDC/psqlgraph/compare/develop...chore/uuid-constraints) that adds constraints and coercion at the application layer (though I believe edge ids would still need to be updated). This allows deployment without migration, however I think we should enforce this at the database level if possible.
