### PR TITLE
fix(hooks): handle nonetype columns on edges

### DIFF
--- a/psqlgraph/hooks.py
+++ b/psqlgraph/hooks.py
@@ -25,8 +25,15 @@ def get_old_version(target, *attrs):
 
     sysan, props = dict(), dict()
     for attr in attrs:
-        props.update(history(target, '_props', attr))
-        sysan.update(history(target, '_sysan', attr))
+        old_props = history(target, '_props', attr)
+        if old_props is None:
+            old_props = {}
+        props.update(old_props)
+
+        old_sysan = history(target, '_sysan', attr)
+        if old_sysan is None:
+            old_sysan = {}
+        sysan.update(old_sysan)
     return props, sysan
 
 


### PR DESCRIPTION
Fixes issue introduced by server side creation of edges with `null` columns

r? @madopal 
cc @BedfordWest 