### PR TITLE
Update psycopg2 version to 2.7.3.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     name='psqlgraph',
     packages=["psqlgraph"],
     install_requires=[
-        'psycopg2==2.7.3',
+        'psycopg2==2.7.3.2',
         'sqlalchemy==0.9.9',
         'py2neo==2.0.1',
         'progressbar',


### PR DESCRIPTION
Update psycopg2 to version 2.7.3.2 so both psqlgraph and signpost have the same version