### PR TITLE
__declare_last__ should be part of a mixin

### DIFF
--- a/psqlgraph/edge.py
+++ b/psqlgraph/edge.py
@@ -22,7 +22,23 @@ def id_column(tablename, class_name):
     )
 
 
-class Edge(AbstractConcreteBase, ORMBase):
+class DeclareLastEdgeMixin(object):
+    @classmethod
+    def __declare_last__(cls):
+        if cls.__name__ == 'Edge':
+            return
+
+        assert hasattr(cls, '__src_class__'), \
+            'You must declare __src_class__ for {}'.format(cls)
+        assert hasattr(cls, '__dst_class__'), \
+            'You must declare __dst_class__ for {}'.format(cls)
+        assert hasattr(cls, '__src_dst_assoc__'), \
+            'You must declare __src_dst_assoc__ for {}'.format(cls)
+        assert hasattr(cls, '__dst_src_assoc__'), \
+            'You must declare __dst_src_assoc__ for {}'.format(cls)
+
+
+class Edge(AbstractConcreteBase, ORMBase, DeclareLastEdgeMixin):
     __src_table__ = None
     __dst_table__ = None
 
@@ -45,18 +61,6 @@ class Edge(AbstractConcreteBase, ORMBase):
         if not dst_table and hasattr(cls, "__dst_class__"):
             dst_table = NODE_TABLENAME_SCHEME.format(class_name=cls.__dst_class__.lower())
         return id_column(dst_table, cls.__name__)
-
-    @classmethod
-    def __declare_last__(cls):
-        for scls in Edge.get_subclasses():
-            assert hasattr(scls, '__src_class__'), \
-                'You must declare __src_class__ for {}'.format(scls)
-            assert hasattr(scls, '__dst_class__'), \
-                'You must declare __dst_class__ for {}'.format(scls)
-            assert hasattr(scls, '__src_dst_assoc__'), \
-                'You must declare __src_dst_assoc__ for {}'.format(scls)
-            assert hasattr(scls, '__dst_src_assoc__'), \
-                'You must declare __dst_src_assoc__ for {}'.format(scls)
 
     @declared_attr
     def __table_args__(cls):


### PR DESCRIPTION
Turned out that `__declare_last__` was never meant to be triggered if it was part of a `declarative_base` subclass and the issue was fixed here:
https://github.com/zzzeek/sqlalchemy/commit/4c931b2ec7e0f09ac8c3ebe28c794f5858d54efb

The problem with the current implementation is that `declared_attr` is not properly populated on the child class, but instead shared among all of the instances.

As the doc strings suggested, current change creates 2 mixins instead (one for `Edge` and one for `Node`).