### PR TITLE
[FIX] Advance SQLAlchemy

### DIFF
--- a/psqlgraph/base.py
+++ b/psqlgraph/base.py
@@ -46,10 +46,6 @@ class CommonBase(object):
         server_default='{}',
     )
 
-    @classmethod
-    def get_label(cls):
-        return getattr(cls, '__label__', cls.__name__.lower())
-
     # ======== Table Attributes ========
     @declared_attr
     def __mapper_args__(cls):
@@ -171,24 +167,14 @@ class CommonBase(object):
         return key in cls.get_property_list()
 
     # ======== Label ========
-    @hybrid_property
-    def label(self):
-        """Custom label on the model
 
-        .. note: This is not the polymorphic identity, see `_type`
-        """
-        return self.get_label()
+    @classmethod
+    def get_label(cls):
+        return getattr(cls, '__label__', cls.__name__.lower())
 
-    @label.setter
-    def label(self, label):
-        """Custom setter as an application level ban from changing labels.
-
-        """
-        if not isinstance(self.label, sqlalchemy.Column)\
-           and self.get_label() is not None\
-           and self.get_label() != label:
-            raise AttributeError('Cannot change label from {} to {}'.format(
-                self.get_label(), label))
+    @declared_attr
+    def label(cls):
+        return cls.get_label()
 
     # ======== System Annotations ========
     @hybrid_property

--- a/psqlgraph/edge.py
+++ b/psqlgraph/edge.py
@@ -219,22 +219,6 @@ class Edge(AbstractConcreteBase, ORMBase, DeclareLastEdgeMixin):
         voided = VoidedEdge(temp)
         session.add(voided)
 
-    # ======== Label ========
-    @hybrid_property
-    def label(self):
-        return self.get_label()
-
-    @label.setter
-    def label(self, label):
-        """Custom setter as an application level ban from changing labels.
-
-        """
-        if not isinstance(self.label, sqlalchemy.Column) \
-                and self.get_label() is not None \
-                and self.get_label() != label:
-            raise AttributeError('Cannot change label from {} to {}'.format(
-                self.get_label(), label))
-
 
 def PolyEdge(src_id=None, dst_id=None, label=None, acl=None, system_annotations=None, properties=None):
     if not label:

--- a/psqlgraph/node.py
+++ b/psqlgraph/node.py
@@ -169,7 +169,6 @@ class Node(AbstractConcreteBase, ORMBase, NodeAssociationProxyMixin):
         self._props = {}
         self.system_annotations = system_annotations or {}
         self.acl = acl or []
-        self.label = label or self.get_label()
         self.properties = properties or {}
         self.properties.update(kwargs)
         self.node_id = node_id


### PR DESCRIPTION
* Changed to `declared_attr` so we don't need to manually set label

Note: there are various places where we set label (ie. in a constructor) so we might need to clean that up.