### PR TITLE
feat(models): allow dynamic base class

### DIFF
--- a/psqlgraph/base.py
+++ b/psqlgraph/base.py
@@ -351,7 +351,7 @@ def drop_all(engine, base=ORMBase):
 
 
 class ExtMixin(object):
-    """  An extension mixin used for """
+    """  An extension mixin used for retrieving child classes when needed """
 
     @classmethod
     def is_subclass_loaded(cls, name):

--- a/psqlgraph/edge.py
+++ b/psqlgraph/edge.py
@@ -128,14 +128,18 @@ class AbstractEdge(DeclareLastEdgeMixin, base.ExtMixin):
 
     @classmethod
     def from_json(cls, edge_json):
-        abstract_edge_cls = cls.get_node_class().get_edge_class()
-        Type = abstract_edge_cls.get_unique_subclass(edge_json['src_label'],
-                                            edge_json['label'],
-                                            edge_json['dst_label'])
+
+        if cls.is_abstract_base():
+            abstract_edge_cls = cls.get_node_class().get_edge_class()
+            Type = abstract_edge_cls.get_unique_subclass(edge_json['src_label'],
+                                                edge_json['label'],
+                                                edge_json['dst_label'])
         
-        if not Type:
-            raise KeyError('Edge has no subclass named {}'
-                               .format(edge_json['label']))
+            if not Type:
+                raise KeyError('Edge has no subclass named {}'
+                                   .format(edge_json['label']))
+        else:
+            Type = cls
 
         return Type(src_id=edge_json['src_id'],
                     dst_id=edge_json['dst_id'],

--- a/psqlgraph/edge.py
+++ b/psqlgraph/edge.py
@@ -30,7 +30,7 @@ class DeclareLastEdgeMixin(object):
 
     @classmethod
     def __declare_last__(cls):
-        if cls.__name__ == 'Edge' or cls.is_abstract_base():
+        if cls.is_abstract_base():
             return
 
         assert hasattr(cls, '__src_class__'), \

--- a/psqlgraph/ext.py
+++ b/psqlgraph/ext.py
@@ -1,0 +1,106 @@
+from collections import defaultdict
+
+import sqlalchemy
+from sqlalchemy.ext.declarative import declarative_base
+
+from psqlgraph import Node, Edge
+from psqlgraph.base import CommonBase, LocalConcreteBase
+from psqlgraph.edge import AbstractEdge
+from psqlgraph.node import AbstractNode
+
+BASE_CLASSES = defaultdict(dict)
+BASE_CLASSES["_"] = {'node': Node, 'edge': Edge}
+
+ORM_BASES = defaultdict(lambda: declarative_base(cls=CommonBase))
+
+
+def get_orm_base(package_namespace):
+    """ Helper function to get the appropriate sqlalchemy base class
+    Args:
+       package_namespace (str): module namespace
+    """
+    return ORM_BASES[package_namespace]
+
+
+def get_abstract_edge(package_namespace=None):
+    package_namespace = package_namespace or "_"
+    return BASE_CLASSES[package_namespace]["edge"]
+
+
+def get_abstract_node(package_namespace=None):
+    package_namespace = package_namespace or "_"
+    return BASE_CLASSES[package_namespace]["node"]
+
+
+def get_class_prefix(pkg_namespace):
+    """ Return an abstract class name prefix for the provided package
+    Args:
+        pkg_namespace (str): valid package name e.g gpas, bio
+    Returns:
+        str: class name prefix eg. AbstractGpas
+    """
+    return "{}".format(pkg_namespace.title())
+
+
+def create_base_class(pkg_namespace, is_node=True):
+    """ Dynamically creates an abstract base class that extends either the Node or Edge class
+    Args:
+        pkg_namespace (str): package namespace
+        is_node (bool): if True creates a node abstract class else creates an edge
+    Returns:
+        class: A dynamically generated abstract class
+    """
+
+    base_class = AbstractNode if is_node else AbstractEdge
+    name = "{}{}".format(get_class_prefix(pkg_namespace), base_class.__name__)
+    return type(name, (LocalConcreteBase, base_class, get_orm_base(pkg_namespace)), {})
+
+
+def register_base_class(package_namespace=None):
+    """ Gets or returns proper base node and edge classes as tuple for the package namespace
+        Example:
+            if package_namespace = `bio`
+            This function will dynamically create and cache the following classes
+                * `psqlgraph.ext.BioAbstractNode`
+                * `psqlgraph.ext.BioAbstractEdge`
+            Custom entities can now extend these class
+            >>> N, E = register_base_class("bio")
+            >>> class Node1(N):
+            >>>    prop = sqlalchemy.Column(sqlalchemy.String)
+            >>> class Edge1(E):
+            >>>    prop = sqlalchemy.Column(sqlalchemy.TEXT)
+    Args:
+        package_namespace (str): If None, defaults to normal Node and Edge class
+    Returns:
+        tuple (class, class):
+    """
+
+    package_namespace = package_namespace or "_"
+    abstract_node = BASE_CLASSES[package_namespace].get("node")
+    abstract_edge = BASE_CLASSES[package_namespace].get("edge")
+
+    if abstract_node:
+        return abstract_node, abstract_edge
+
+    # dynamically create base classes
+    abstract_node = create_base_class(package_namespace, is_node=True)
+    abstract_edge = create_base_class(package_namespace, is_node=False)
+
+    @classmethod
+    def get_node_class(cls):
+        return abstract_node
+
+    @classmethod
+    def get_edge_class(cls):
+        return abstract_edge
+
+    abstract_node.get_edge_class = get_edge_class
+    abstract_edge.get_node_class = get_node_class
+
+    globals()[abstract_node.__name__] = abstract_node
+    globals()[abstract_edge.__name__] = abstract_edge
+
+    BASE_CLASSES[package_namespace]["node"] = abstract_node
+    BASE_CLASSES[package_namespace]["edge"] = abstract_edge
+
+    return abstract_node, abstract_edge

--- a/psqlgraph/ext.py
+++ b/psqlgraph/ext.py
@@ -1,7 +1,6 @@
 from collections import defaultdict
 
-import sqlalchemy
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.ext import declarative
 
 from psqlgraph import Node, Edge
 from psqlgraph.base import CommonBase, LocalConcreteBase
@@ -9,9 +8,9 @@ from psqlgraph.edge import AbstractEdge
 from psqlgraph.node import AbstractNode
 
 BASE_CLASSES = defaultdict(dict)
-BASE_CLASSES["_"] = {'node': Node, 'edge': Edge}
+BASE_CLASSES[None] = {'node': Node, 'edge': Edge}
 
-ORM_BASES = defaultdict(lambda: declarative_base(cls=CommonBase))
+ORM_BASES = defaultdict(lambda: declarative.declarative_base(cls=CommonBase))
 
 
 def get_orm_base(package_namespace):
@@ -23,12 +22,10 @@ def get_orm_base(package_namespace):
 
 
 def get_abstract_edge(package_namespace=None):
-    package_namespace = package_namespace or "_"
     return BASE_CLASSES[package_namespace]["edge"]
 
 
 def get_abstract_node(package_namespace=None):
-    package_namespace = package_namespace or "_"
     return BASE_CLASSES[package_namespace]["node"]
 
 
@@ -57,7 +54,7 @@ def create_base_class(pkg_namespace, is_node=True):
 
 
 def register_base_class(package_namespace=None):
-    """ Gets or returns proper base node and edge classes as tuple for the package namespace
+    """ Registers or returns a registered base node and edge classes as tuple for the package namespace
         Example:
             if package_namespace = `bio`
             This function will dynamically create and cache the following classes
@@ -75,7 +72,6 @@ def register_base_class(package_namespace=None):
         tuple (class, class):
     """
 
-    package_namespace = package_namespace or "_"
     abstract_node = BASE_CLASSES[package_namespace].get("node")
     abstract_edge = BASE_CLASSES[package_namespace].get("edge")
 

--- a/psqlgraph/hooks.py
+++ b/psqlgraph/hooks.py
@@ -2,8 +2,10 @@
 Session hooks
 """
 from sqlalchemy.inspection import inspect
-from psqlgraph.node import Node
-from psqlgraph.edge import Edge
+
+from psqlgraph.base import ExtMixin
+from psqlgraph.edge import AbstractEdge
+from psqlgraph.node import AbstractNode
 
 
 def history(target, column, attr):
@@ -41,8 +43,7 @@ def is_psqlgraph_entity(target):
     """Only attempt to track history on Nodes and Edges
 
     """
-    return target.__class__ in (
-        Node.__subclasses__()+Edge.__subclasses__())
+    return isinstance(target, ExtMixin)
 
 
 def receive_before_flush(session, flush_context, instances):
@@ -98,7 +99,7 @@ def receive_before_flush(session, flush_context, instances):
         if not is_psqlgraph_entity(target):
             continue
 
-        if isinstance(target, (Node, Edge)):
+        if isinstance(target, (AbstractNode, AbstractEdge)):
             target._validate()
 
         # Call custom session hook

--- a/psqlgraph/node.py
+++ b/psqlgraph/node.py
@@ -6,8 +6,8 @@ from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import relationship
 
+from psqlgraph import base
 from psqlgraph.edge import Edge
-from psqlgraph.base import ExtMixin, LocalConcreteBase, ORMBase, NODE_TABLENAME_SCHEME
 from psqlgraph.voided_node import VoidedNode
 
 
@@ -105,7 +105,7 @@ class NodeAssociationProxyMixin(object):
         return Edge
 
 
-class AbstractNode(NodeAssociationProxyMixin, ExtMixin):
+class AbstractNode(NodeAssociationProxyMixin, base.ExtMixin):
 
     node_id = Column(
         Text,
@@ -115,7 +115,7 @@ class AbstractNode(NodeAssociationProxyMixin, ExtMixin):
 
     @declared_attr
     def __tablename__(cls):
-        return NODE_TABLENAME_SCHEME.format(class_name=cls.__name__.lower())
+        return base.NODE_TABLENAME_SCHEME.format(class_name=cls.__name__.lower())
 
     @declared_attr
     def __table_args__(cls):
@@ -300,7 +300,7 @@ class AbstractNode(NodeAssociationProxyMixin, ExtMixin):
         session.add(voided)
 
 
-class Node(LocalConcreteBase, AbstractNode, ORMBase):
+class Node(base.LocalConcreteBase, AbstractNode, base.ORMBase):
     pass
 
 

--- a/psqlgraph/node.py
+++ b/psqlgraph/node.py
@@ -250,12 +250,17 @@ class AbstractNode(NodeAssociationProxyMixin, base.ExtMixin):
 
     @classmethod
     def from_json(cls, node_json):
-        abstract_node_cls = cls.get_edge_class().get_node_class()
-        Type = abstract_node_cls.get_subclass(node_json["label"])
+        """ loads a node instance from a json object """
 
-        if not Type:
-            raise KeyError('Node has no subclass named {}'
-                               .format(node_json['label']))
+        if cls.is_abstract_base():
+            abstract_node_cls = cls.get_edge_class().get_node_class()
+            Type = abstract_node_cls.get_subclass(node_json["label"])
+
+            if not Type:
+                raise KeyError('Node has no subclass named {}'
+                                   .format(node_json['label']))
+        else:
+            Type = cls
 
         return Type(node_id=node_json['node_id'],
                     properties=node_json['properties'],

--- a/psqlgraph/node.py
+++ b/psqlgraph/node.py
@@ -2,12 +2,12 @@ from collections import deque
 
 from sqlalchemy import Column, Text, UniqueConstraint, Index
 from sqlalchemy.ext.associationproxy import association_proxy
-from sqlalchemy.ext.declarative import AbstractConcreteBase, declared_attr
+from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import relationship
 
 from psqlgraph.edge import Edge
-from psqlgraph.base import ORMBase, NODE_TABLENAME_SCHEME
+from psqlgraph.base import ExtMixin, LocalConcreteBase, ORMBase, NODE_TABLENAME_SCHEME
 from psqlgraph.voided_node import VoidedNode
 
 
@@ -41,7 +41,12 @@ class NodeAssociationProxyMixin(object):
         The actual change:
         https://github.com/zzzeek/sqlalchemy/commit/4c931b2ec7e0f09ac8c3ebe28c794f5858d54efb
         """
-        for scls in Edge.get_subclasses():
+
+        edge_cls = cls.get_edge_class()
+        for scls in edge_cls.get_subclasses():
+
+            if scls.is_abstract_base():
+                continue
 
             name = scls.__name__
             name_in = '_{}_in'.format(name)
@@ -95,8 +100,13 @@ class NodeAssociationProxyMixin(object):
         for edge_out in self.edges_out:
             yield edge_out
 
+    @classmethod
+    def get_edge_class(cls):
+        return Edge
 
-class Node(AbstractConcreteBase, ORMBase, NodeAssociationProxyMixin):
+
+class AbstractNode(NodeAssociationProxyMixin, ExtMixin):
+
     node_id = Column(
         Text,
         primary_key=True,
@@ -221,7 +231,7 @@ class Node(AbstractConcreteBase, ORMBase, NodeAssociationProxyMixin):
         return hash((self.node_id, self.__class__))
 
     def copy(self):
-        node = Node(
+        node = self.__class__(
             node_id=self.node_id,
             acl=self.acl,
             _system_annotations=self.system_annotations,
@@ -240,13 +250,12 @@ class Node(AbstractConcreteBase, ORMBase, NodeAssociationProxyMixin):
 
     @classmethod
     def from_json(cls, node_json):
-        if cls is Node:
-            Type = Node.get_subclass(node_json['label'])
-            if not Type:
-                raise KeyError('Node has no subclass named {}'
-                                  .format(node_json['label']))
-        else:
-            Type = cls
+        abstract_node_cls = cls.get_edge_class().get_node_class()
+        Type = abstract_node_cls.get_subclass(node_json["label"])
+
+        if not Type:
+            raise KeyError('Node has no subclass named {}'
+                               .format(node_json['label']))
 
         return Type(node_id=node_json['node_id'],
                     properties=node_json['properties'],
@@ -256,25 +265,17 @@ class Node(AbstractConcreteBase, ORMBase, NodeAssociationProxyMixin):
                    
     @classmethod
     def get_subclass(cls, label):
-        for c in cls.__subclasses__():
+        for c in cls.get_subclasses():
             if c.get_label() == label:
                 return c
         return None
 
     @classmethod
     def get_subclass_named(cls, name):
-        for c in cls.__subclasses__():
+        for c in cls.get_subclasses():
             if c.__name__ == name:
                 return c
         raise KeyError('Node has no subclass named {}'.format(name))
-
-    @staticmethod
-    def get_subclass_table_names():
-        return [s.__tablename__ for s in Node.__subclasses__()]
-
-    @classmethod
-    def get_subclasses(cls):
-        return [s for s in cls.__subclasses__()]
 
     @property
     def _history(self):
@@ -297,6 +298,10 @@ class Node(AbstractConcreteBase, ORMBase, NodeAssociationProxyMixin):
                        old_sysan, self.label, self.created)
         voided = VoidedNode(temp)
         session.add(voided)
+
+
+class Node(LocalConcreteBase, AbstractNode, ORMBase):
+    pass
 
 
 class TmpNode(object):

--- a/psqlgraph/psql.py
+++ b/psqlgraph/psql.py
@@ -42,7 +42,7 @@ class PsqlGraphDriver(object):
         """
 
         # Parse kwargs
-        self.package_namespace = kwargs.pop("package_namespace", "_")
+        self.package_namespace = kwargs.pop("package_namespace", None)
         connect_args = kwargs.pop('connect_args', {})
         kwargs.pop('node_validator', None)
         kwargs.pop('edge_validator', None)

--- a/psqlgraph/psql.py
+++ b/psqlgraph/psql.py
@@ -13,10 +13,11 @@ from xlocal import xlocal
 import socket
 
 # Custom modules
-from psqlgraph.edge import Edge
+from psqlgraph import ext
+from psqlgraph.edge import AbstractEdge
 from psqlgraph.exc import QueryError
 from psqlgraph.hooks import receive_before_flush
-from psqlgraph.node import PolyNode, Node
+from psqlgraph.node import PolyNode
 from psqlgraph.query import GraphQuery
 from psqlgraph.util import retryable, default_backoff
 from psqlgraph.voided_edge import VoidedEdge
@@ -41,6 +42,7 @@ class PsqlGraphDriver(object):
         """
 
         # Parse kwargs
+        self.package_namespace = kwargs.pop("package_namespace", "_")
         connect_args = kwargs.pop('connect_args', {})
         kwargs.pop('node_validator', None)
         kwargs.pop('edge_validator', None)
@@ -79,7 +81,7 @@ class PsqlGraphDriver(object):
     def _new_session(self):
         Session = sessionmaker(expire_on_commit=False, class_=GraphSession)
         Session.configure(bind=self.engine, query_cls=GraphQuery)
-        session = Session()
+        session = Session(package_namespace=self.package_namespace)
         session._flush_timestamp = None
         session._set_flush_timestamps = self.set_flush_timestamps
         event.listen(session, 'before_flush', receive_before_flush)
@@ -200,10 +202,11 @@ class PsqlGraphDriver(object):
                 local.expunge_all()
                 local.close()
 
-    def nodes(self, query=Node):
+    def nodes(self, query=None):
         """.. _nodes:
 
         """
+        query = query or ext.get_abstract_node(self.package_namespace)
         self._configure_driver_mappers()
         with self.session_scope(must_inherit=True) as local:
             if isinstance(query, list) or isinstance(query, tuple):
@@ -214,7 +217,8 @@ class PsqlGraphDriver(object):
     def __call__(self, *args, **kwargs):
         return self.nodes(*args, **kwargs)
 
-    def edges(self, query=Edge):
+    def edges(self, query=None):
+        query = query or ext.get_abstract_edge(self.package_namespace)
         self._configure_driver_mappers()
         with self.session_scope(must_inherit=True) as local:
             if isinstance(query, list) or isinstance(query, tuple):
@@ -276,7 +280,7 @@ class PsqlGraphDriver(object):
                 node = self.nodes().ids([node_id]).scalar()
 
             elif not node and label:
-                cls = Node.get_subclass(label)
+                cls = ext.get_abstract_node(self.package_namespace).get_subclass(label)
                 node = self.nodes(cls).ids([node_id]).scalar()
 
             if not node:
@@ -318,7 +322,7 @@ class PsqlGraphDriver(object):
         elif not label:
             query = self.nodes()
         else:
-            cls = Node.get_subclass(label)
+            cls = ext.get_abstract_node(self.package_namespace).get_subclass(label)
             query = self.nodes(cls)
 
         if node_id is not None:
@@ -428,7 +432,9 @@ class PsqlGraphDriver(object):
         if voided:
             queries = [self.voided_edges()]
         elif label is not None:
-            queries = [self.edges(cls) for cls in Edge._get_subclasses_labeled(label)]
+            edge_cls = ext.get_abstract_edge(self.package_namespace)
+            queries = [self.edges(cls) for cls in \
+                       edge_cls._get_subclasses_labeled(label)]
         else:
             queries = [self.edges()]
 
@@ -455,21 +461,25 @@ class PsqlGraphDriver(object):
 
     def edge_delete_by_node_id(self, node_id, session=None):
         with self.session_scope(session) as local:
-            for edge in self.edges().filter(Edge.src_id == node_id):
+            edge_cls = ext.get_abstract_edge(self.package_namespace)
+            for edge in self.edges().filter(edge_cls.src_id == node_id):
                 local.delete(edge)
-            for edge in self.edges().filter(Edge.dst_id == node_id):
+            for edge in self.edges().filter(edge_cls.dst_id == node_id):
                 local.delete(edge)
 
     def get_edge_by_labels(self, src_label, edge_label, dst_label):
-        src_classes = [n for n in Node.get_subclasses()
+        node_cls = ext.get_abstract_node(self.package_namespace)
+        src_classes = [n for n in node_cls.get_subclasses()
                        if n.get_label() == src_label]
-        dst_classes = [n for n in Node.get_subclasses()
+        dst_classes = [n for n in node_cls.get_subclasses()
                        if n.get_label() == dst_label]
         assert len(src_classes) == 1,\
             'No classes found with src_label {}'.format(src_label)
         assert len(dst_classes) == 1,\
             'No classes found with dst_label {}'.format(dst_label)
-        edges = [edge for edge in Edge.get_subclasses()
+
+        edge_cls = ext.get_abstract_edge(self.package_namespace)
+        edges = [edge for edge in edge_cls.get_subclasses()
                  if edge.__src_class__ == src_classes[0].__name__
                  and edge.__dst_class__ == dst_classes[0].__name__
                  and edge.get_label() == edge_label]
@@ -494,7 +504,7 @@ class PsqlGraphDriver(object):
     def reload(self, *entities):
         reloaded = []
         for e in entities:
-            if isinstance(e, Edge):
+            if isinstance(e, AbstractEdge):
                 reloaded.append(self.edges(type(e)).src(e.src_id)
                                 .dst(e.dst_id).one())
             else:

--- a/psqlgraph/session.py
+++ b/psqlgraph/session.py
@@ -18,7 +18,7 @@ class GraphSession(Session):
     def __init__(self, *args, **kwargs):
 
         self._psqlgraph_closed = False
-        self.package_namespace = kwargs.pop("package_namespace", "_")
+        self.package_namespace = kwargs.pop("package_namespace", None)
         super(GraphSession, self).__init__(*args, **kwargs)
 
     @inherit_docstring_from(Session)

--- a/psqlgraph/session.py
+++ b/psqlgraph/session.py
@@ -18,7 +18,7 @@ class GraphSession(Session):
     def __init__(self, *args, **kwargs):
 
         self._psqlgraph_closed = False
-
+        self.package_namespace = kwargs.pop("package_namespace", "_")
         super(GraphSession, self).__init__(*args, **kwargs)
 
     @inherit_docstring_from(Session)
@@ -41,3 +41,8 @@ class GraphSession(Session):
         self._psqlgraph_closed = True
 
         return super(GraphSession, self).close()
+
+    def query(self, *entities, **kwargs):
+        kwargs["package_namespace"] = self.package_namespace
+        return super(GraphSession, self).query(*entities, **kwargs)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-psycopg2-binary==2.8.2
-sqlalchemy==1.3.3
-xlocal==0.5
-requests==2.22.0
-rstr==2.2.6
-six==1.12.0
+psycopg2-binary
+sqlalchemy
+xlocal
+requests
+rstr
+six>=1.12.0

--- a/test/test_extensions.py
+++ b/test/test_extensions.py
@@ -1,0 +1,39 @@
+import pytest
+
+from psqlgraph import ext
+from psqlgraph.edge import AbstractEdge, Edge
+from psqlgraph.node import AbstractNode, Node
+
+
+@pytest.mark.parametrize(
+    "ns, node_cls_name, edge_cls_name", [
+    ("sample", "SampleAbstractNode", "SampleAbstractEdge"),
+    ("test", "TestAbstractNode", "TestAbstractEdge"),
+    (None, "Node", "Edge")
+])
+def test_register_bases(ns, node_cls_name, edge_cls_name):
+
+    node_cls, edge_cls = ext.register_base_class(package_namespace=ns)
+    assert issubclass(node_cls, AbstractNode)
+    assert issubclass(edge_cls, AbstractEdge)
+
+    assert node_cls.__name__ == node_cls_name
+    assert edge_cls.__name__ == edge_cls_name
+
+
+@pytest.mark.parametrize(
+    "ns", ["sample", "test", None])
+def test_bases_cached(ns):
+    node_cls, edge_cls = ext.register_base_class(package_namespace=ns)
+
+    node_cls_1, edge_cls_1 = ext.register_base_class(package_namespace=ns)
+    assert node_cls == node_cls_1
+    assert edge_cls == edge_cls_1
+
+
+def test_abstract_defaults():
+    node_cls = ext.get_abstract_node()
+    assert node_cls == Node
+
+    edge_cls = ext.get_abstract_edge()
+    assert edge_cls == Edge

--- a/test/test_extensions_crud.py
+++ b/test/test_extensions_crud.py
@@ -1,0 +1,56 @@
+from psqlgraph import ext, create_all, PsqlGraphDriver, pg_property
+from psqlgraph.base import drop_all
+
+MdaNode, MdaEdge = ext.register_base_class(package_namespace="mda")
+
+
+class E1(MdaEdge):
+
+    __label__ = "edge_t1_t2"
+    __src_class__ = 'T1'
+    __dst_class__ = 'T2'
+    __src_dst_assoc__ = 't2s'
+    __dst_src_assoc__ = 't1s'
+
+
+class T2(MdaNode):
+
+    _pg_edges = {}
+
+    @pg_property
+    def bar(self, value):
+        self._set_property('bar', value)
+
+
+class T1(MdaNode):
+
+    _pg_edges = {}
+
+    @pg_property
+    def foo(self, value):
+        self._set_property('foo', value)
+
+
+def test_create_tables(pg_conf):
+
+    g = PsqlGraphDriver(package_namespace="mda", **pg_conf)
+    orm_base = ext.get_orm_base("mda")
+
+    # clean out any existing record
+    drop_all(g.engine, base=orm_base)
+    create_all(g.engine, base=orm_base)
+
+    with g.session_scope() as s:
+        # create sample entries
+        t1 = T1(node_id="t1", foo="spez")
+        t2 = T2(node_id="t2", bar="spez")
+        t1.t2s.append(t2)
+        s.add(t1)
+
+    # sample query
+    with g.session_scope():
+        spezes = g.nodes().props(foo="spez").all()
+        assert len(spezes) == 1
+
+        node = spezes[0]
+        assert node.label == "t1"


### PR DESCRIPTION
Adds functionality to dynamically create base node and edge classes for different namespaces so as to enable using with two or more dictionaries without conflicts