### PR TITLE
DEV-420 support prop_in for Node class and list types

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,9 +1,9 @@
 {
   "exclude": {
-    "files": null,
+    "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2020-10-14T14:17:18Z",
+  "generated_at": "2020-10-29T22:44:48Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -28,21 +28,12 @@
     }
   ],
   "results": {
-    "psql-users.sh": [
-      {
-        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 1,
-        "type": "Secret Keyword"
-      }
-    ],
     "psqlgraph/psql.py": [
       {
         "hashed_secret": "f0e2d8610edefa0c02b673dcac7964b02ce3e890",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 57,
+        "line_number": 59,
         "type": "Basic Auth Credentials"
       }
     ],

--- a/psqlgraph/query.py
+++ b/psqlgraph/query.py
@@ -553,17 +553,11 @@ class GraphQuery(Query):
 
 
 def is_list_prop(entity, prop):
-    """Determine if a property on an entity is a list type.
-
-    The Node type is a special case because it has no properties but its
-    subclasses do have them. It's also special in that it's the only node
-    type with subclasses. Going through the subclasses to find a matching
-    type will allow us to make a g.nodes() query with no parameters. By default
-    g.nodes() with no parameters will use gdcdatamodel.models.Node, so we need
-    special logic to check the subclasses.
-    """
+    """Determine if a property on an entity is a list type."""
     if entity.label == 'node':
-        # All data models subclass node, but have no subclasses of their own.
+        # By default a query that starts with g.nodes() will use
+        # gdcdatamodel.models.Node as the node type. We want prop_in to
+        # continue to work for list types so check Node's subclasses.
         for subclass in entity.get_subclasses():
             if list in subclass.__pg_properties__.get(prop, {}):
                 return True

--- a/psqlgraph/query.py
+++ b/psqlgraph/query.py
@@ -553,7 +553,20 @@ class GraphQuery(Query):
 
 
 def is_list_prop(entity, prop):
-    if prop not in entity.__pg_properties__:
-        raise KeyError("{} has not attribute {}".format(entity.__class__, prop))
-    return list in entity.__pg_properties__[prop]
+    """Determine if a property on an entity is a list type.
 
+    The Node type is a special case because it has no properties but its
+    subclasses do have them. It's also special in that it's the only node
+    type with subclasses. Going through the subclasses to find a matching
+    type will allow us to make a g.nodes() query with no parameters. By default
+    g.nodes() with no parameters will use gdcdatamodel.models.Node, so we need
+    special logic to check the subclasses.
+    """
+    if entity.label == 'node':
+        # All data models subclass node, but have no subclasses of their own.
+        for subclass in entity.get_subclasses():
+            if list in subclass.__pg_properties__.get(prop, {}):
+                return True
+
+    # Default value of dict because __pg_properties__ is a dict.
+    return list in entity.__pg_properties__.get(prop, {})

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -128,6 +128,7 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
                              .count(), self.g.nodes(models.Foo).count())
 
 
+@pytest.mark.parametrize("node_type", [models.Foo, models.Node])
 @pytest.mark.parametrize(
     "col, vals, expected_count", [
         ("studies", ["C1"], 1),
@@ -135,8 +136,16 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
         ("studies", ["XP2"], 0),
         ("studies", ["C1", "P1"], 2),
 ])
-def test_props_in(pg_driver, samples_with_array, col, vals, expected_count):
-    # filter
+def test__props_in__list(pg_driver, samples_with_array, node_type, col, vals, expected_count):
     with pg_driver.session_scope() as s:
-        r = pg_driver.nodes(models.Foo).prop_in(col, vals).count()
+        # studies is type list
+        r = pg_driver.nodes(node_type).prop_in(col, vals).count()
         assert r == expected_count
+
+
+@pytest.mark.parametrize("node_type", [models.Foo, models.Node])
+def test__props_in__int(pg_driver, samples_with_array, node_type):
+    with pg_driver.session_scope() as s:
+        # fobble is type int
+        r = pg_driver.nodes(node_type).prop_in("fobble", [25]).count()
+        assert r == 3


### PR DESCRIPTION
I added more test coverage and tried it in the repl using some qa-generated test data that was already there. Using the query `g.nodes().prop_in()` without specifying the node type (in this case Diagnosis) would result in an exception if the prop was listed as an array type in the gdcdictionary. Now it gives the correct result back.


```python
In [1]: g.nodes().prop_in('sites_of_involvement', ["Kidney, Middle"]).count()                                                                 
Out[1]: 1

In [2]: g.nodes().prop_in('sites_of_involvement', ["Kidney, Middle"]).first().sites_of_involvement                                            
Out[2]: 
['Ovary, NOS',
 'Ovary, Right',
 'Uterus',
 'Abdominal Peritoneum',
 'Ovary, Left',
 'Cervix',
 'Not Reported',
 'Kidney, Middle',
 'Unknown',
 'Omentum',
 'Kidney, Lower Pole',
 'Pelvic Peritoneum']
```

After this is merged and tagged I can go around updating all of the other repos with this pin.