### PR TITLE
Feat/dev 40 assign default value

### DIFF
--- a/psqlgraph/node.py
+++ b/psqlgraph/node.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import relationship
 from psqlgraph import base
 from psqlgraph.edge import Edge
 from psqlgraph.voided_node import VoidedNode
+from psqlgraph.util import sanitize
 
 
 DST_SRC_ASSOC = '__dst_src_assoc__'
@@ -206,7 +207,10 @@ class AbstractNode(NodeAssociationProxyMixin, base.ExtMixin):
 
     def __init__(self, node_id=None, properties=None, acl=None,
                  system_annotations=None, label=None, **kwargs):
-        self._props = {}
+        try:
+            self._props = sanitize(self._defaults)
+        except AttributeError:
+            self._props = {}
         self.system_annotations = system_annotations or {}
         self.acl = acl or []
         self.properties = properties or {}

--- a/psqlgraph/node.py
+++ b/psqlgraph/node.py
@@ -210,10 +210,14 @@ class AbstractNode(NodeAssociationProxyMixin, base.ExtMixin):
         self._props = {}
         self.system_annotations = system_annotations or {}
         self.acl = acl or []
-        self.properties = sanitize(getattr(self, "_defaults", {}))
+        self.properties = self._defaults
         self.properties.update(properties)
         self.properties.update(kwargs)
         self.node_id = node_id
+
+    @property
+    def _defaults(self):
+        return {}
 
     def __repr__(self):
         return '<{}({node_id})>'.format(

--- a/psqlgraph/node.py
+++ b/psqlgraph/node.py
@@ -8,7 +8,6 @@ from sqlalchemy.orm import relationship
 
 from psqlgraph import base
 from psqlgraph.edge import Edge
-from psqlgraph.util import sanitize
 from psqlgraph.voided_node import VoidedNode
 
 

--- a/psqlgraph/node.py
+++ b/psqlgraph/node.py
@@ -207,13 +207,11 @@ class AbstractNode(NodeAssociationProxyMixin, base.ExtMixin):
 
     def __init__(self, node_id=None, properties=None, acl=None,
                  system_annotations=None, label=None, **kwargs):
-        try:
-            self._props = sanitize(self._defaults)
-        except AttributeError:
-            self._props = {}
+        self._props = {}
         self.system_annotations = system_annotations or {}
         self.acl = acl or []
-        self.properties = properties or {}
+        self.properties = sanitize(getattr(self, "_defaults", {}))
+        self.properties.update(properties)
         self.properties.update(kwargs)
         self.node_id = node_id
 

--- a/psqlgraph/node.py
+++ b/psqlgraph/node.py
@@ -8,8 +8,8 @@ from sqlalchemy.orm import relationship
 
 from psqlgraph import base
 from psqlgraph.edge import Edge
-from psqlgraph.voided_node import VoidedNode
 from psqlgraph.util import sanitize
+from psqlgraph.voided_node import VoidedNode
 
 
 DST_SRC_ASSOC = '__dst_src_assoc__'

--- a/test/models.py
+++ b/test/models.py
@@ -51,10 +51,20 @@ class FakeDictionary(object):
             },
             'foo_bar': {
                 'properties': {
-                    'bar': {'type': 'string'}
+                    'bar': {'type': 'string'},
                 },
                 'links': [],
-            }
+            },
+            'test_default_value': {
+                'properties': {
+                    'property_with_default': {
+                        'default': 'open',
+                        'enum': ['open', 'submitted', 'closed', 'legacy']
+                    },
+                    'property_without_default': {'type': 'string'}
+                },
+                'links': [],
+            },
         }
 
 
@@ -169,6 +179,22 @@ class FooBar(Node):
         self._set_property('bar', value)
 
 
+class TestDefaultValue(Node):
+    __label__ = 'test_default_value'
+
+    _pg_edges = {}
+
+    _defaults = {'property_with_default': 'open'}
+
+    @pg_property(enum=('open', 'submitted', 'closed', 'legacy'))
+    def property_with_default(self, value):
+        self._set_property('property_with_default', value)
+
+    @pg_property
+    def property_without_default(self, value):
+        self._set_property('property_without_default', value)
+
+
 Test._pg_edges.update({
     'tests': {
         'backref': '_tests',
@@ -180,6 +206,7 @@ Test._pg_edges.update({
     }
 })
 
+
 Foo._pg_edges.update({
     'foobars': {
         'backref': 'foos',
@@ -190,6 +217,7 @@ Foo._pg_edges.update({
         'type': Test,
     }
 })
+
 
 FooBar._pg_edges.update({
     'foos': {

--- a/test/test_psqlgraph.py
+++ b/test/test_psqlgraph.py
@@ -10,8 +10,6 @@ from parameterized import parameterized
 from multiprocessing import Process
 from sqlalchemy.exc import IntegrityError
 from psqlgraph.exc import ValidationError, EdgeCreationError
-from sqlalchemy.orm.exc import FlushError
-from sqlalchemy.orm.attributes import flag_modified
 
 from datetime import datetime
 from copy import deepcopy
@@ -835,7 +833,6 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
             self.assertDictEqual(new_edge.props, edge.props)
             self.assertDictEqual(new_edge.sysan, edge.sysan)
 
-
     def test_sessioned_path_insertion(self):
         """Test creation of a sessioned node path
 
@@ -907,45 +904,6 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
                 self.assertTrue(dst_id not in set(edges))
             for dst_id in dst_ids:
                 self.assertIs(self.g.edge_lookup_one(dst_id=dst_id), None)
-
-    @unittest.skip('deprecated')
-    def test_node_validator_error(self):
-        """Test node validator error"""
-
-        with self.g.session_scope():
-            node_id = str(uuid.uuid4())
-            temp = self.g.node_validator.validate
-            self.g.node_validator.validate = lambda x: False
-            try:
-                self.assertRaises(
-                    ValidationError,
-                    self.g.node_merge, node_id, label='test',
-                )
-            except:
-                self.g.node_validator.validate = temp
-                raise
-
-    @unittest.skip('deprecated')
-    def test_edge_validator_error(self):
-        """Test edge validator error"""
-
-        with self.g.session_scope():
-            src_id = str(uuid.uuid4())
-            dst_id = str(uuid.uuid4())
-            temp = self.g.edge_validator.validate
-            self.g.edge_validator.validate = lambda x: False
-            self.g.node_merge(src_id, label='test')
-            self.g.node_merge(dst_id, label='test')
-
-            try:
-                self.assertRaises(
-                    ValidationError,
-                    self.g.edge_insert,
-                    PsqlEdge(src_id=src_id, dst_id=dst_id, label='test'),
-                )
-            except:
-                self.g.edge_validator.validate = temp
-                raise
 
     def test_get_nodes(self):
         """Test node get"""

--- a/test/test_psqlgraph.py
+++ b/test/test_psqlgraph.py
@@ -421,7 +421,6 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
             self.assertDictEqual(new_node.sysan, node.sysan)
             self.assertEqual(new_node.node_id, node_id)
 
-
     def _insert_node(self, node):
         """Test inserting a node"""
         with self.g.session_scope() as session:

--- a/test/test_psqlgraph2.py
+++ b/test/test_psqlgraph2.py
@@ -5,6 +5,7 @@ from psqlgraph.exc import ValidationError
 from psqlgraph.exc import SessionClosedError
 import socket
 import sqlalchemy as sa
+import pytest
 
 # We have to import models here, even if we don't use them
 from test import models, PsqlgraphBaseTest
@@ -516,3 +517,22 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
             self.g.nodes(models.Test).null_props('key1', 'key2').one()
             self.g.nodes(models.Test).null_props(['key1', 'key2'], 'key3').one()
             self.g.nodes(models.Test).null_props('key1').one()
+
+
+@pytest.mark.parametrize("sending_default, expected", [
+    [False, 'open'],
+    [True, 'closed'],
+])
+def test_default_value(pg_driver, sending_default, expected):
+    node_id = 'test_default'
+    with pg_driver.session_scope() as s:
+        node = models.TestDefaultValue(node_id)
+        node.property_without_default = 'dummy'
+        if sending_default:
+            node.property_with_default = expected
+        s.add(node)
+    with pg_driver.session_scope() as s:
+        node_added = pg_driver.nodes(models.TestDefaultValue).ids(node_id).one()
+        assert node_added.property_with_default == expected
+        assert node_added.property_without_default == 'dummy'
+        s.delete(node_added)

--- a/test/test_psqlgraph2.py
+++ b/test/test_psqlgraph2.py
@@ -524,6 +524,7 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
     [True, 'closed'],
 ])
 def test_default_value(pg_driver, sending_default, expected):
+    """Test the default value assignment for class with default values"""
     node_id = 'test_default'
     with pg_driver.session_scope() as s:
         node = models.TestDefaultValue(node_id)
@@ -535,4 +536,16 @@ def test_default_value(pg_driver, sending_default, expected):
         node_added = pg_driver.nodes(models.TestDefaultValue).ids(node_id).one()
         assert node_added.property_with_default == expected
         assert node_added.property_without_default == 'dummy'
+        s.delete(node_added)
+
+
+def test_empty__default_property(pg_driver):
+    """Test class without default values should have empty _defaults property"""
+    node_id = 'test_default'
+    with pg_driver.session_scope() as s:
+        test_node = models.Test(node_id)
+        s.add(test_node)
+    with pg_driver.session_scope() as s:
+        node_added = pg_driver.nodes(models.Test).ids(node_id).one()
+        assert node_added._defaults == {}
         s.delete(node_added)


### PR DESCRIPTION
apply the default values from the models if available

If the node class have properties with default value (e.g. [`project` in gdcdictionary](https://github.com/NCI-GDC/gdcdictionary/blob/c09627370f5bf15a3a9ddb07f30d84e49f25f99f/gdcdictionary/schemas/project.yaml#L88)), the data model of that node class is expected to have a `_defaults` property, which is a dictionary of `{property_name: default_value}`. 
`psqlgraph` then picks them up and apply those default values during the creation of new instances from that class.