### PR TITLE
Feat/dev 40 fix mocks

### DIFF
--- a/psqlgraph/mocks.py
+++ b/psqlgraph/mocks.py
@@ -241,7 +241,9 @@ class NodeFactory(object):
             prop_list = self.schema[label].get('required', [])
 
         for prop in prop_list:
-            if prop == 'type':
+            # these two props are excluded during the real node creation
+            # see `excluded_props` in gdcdatamodel.models.__init__.py
+            if prop in ['id', 'type']:
                 continue
 
             try:

--- a/psqlgraph/mocks.py
+++ b/psqlgraph/mocks.py
@@ -242,7 +242,7 @@ class NodeFactory(object):
 
         for prop in prop_list:
             # these two props are excluded during the real node creation
-            # see `excluded_props` in gdcdatamodel.models.__init__.py
+            # see `excluded_props` in gdcdatamodel/models/__init__.py
             if prop in ['id', 'type']:
                 continue
 


### PR DESCRIPTION
fix a minor bug in the `mocks` module

The `id` property should also be skipped during the node creation process along with the `type` as these two properties are
> defined outside of the JSONB columns in the database

as mentioned in the [`excluded_props`](https://github.com/NCI-GDC/gdcdatamodel/blob/8f1c7edf755e09de6d88066fd7b357614664b239/gdcdatamodel/models/__init__.py#L81). 

[The updated logic for applying default value ](https://github.com/NCI-GDC/psqlgraph/blob/0bdd94795e7fa4930523f3fd648ba7ccfb1841e6/psqlgraph/node.py#L213) revealed this. 
