### PR TITLE
dev-955 use label for edge resolving in mocks

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -141,10 +141,10 @@
         "filename": "test/test_mocks.py",
         "hashed_secret": "99ffd88615aaba1c26dbae068b6b6360bd1358a4",
         "is_verified": false,
-        "line_number": 169,
+        "line_number": 171,
         "is_secret": false
       }
     ]
   },
-  "generated_at": "2023-01-03T19:22:09Z"
+  "generated_at": "2023-01-04T22:30:16Z"
 }

--- a/psqlgraph/mocks.py
+++ b/psqlgraph/mocks.py
@@ -559,7 +559,7 @@ class GraphFactory(object):
                 return
             else:
                 logging.warning(
-                    "Edge with label {} not working between nodes {} and {}".format(
+                    "Edge with label {} is not allowed between nodes {} and {}".format(
                         edge_label, src_node.label, dst_node.label
                     )
                 )

--- a/psqlgraph/mocks.py
+++ b/psqlgraph/mocks.py
@@ -4,7 +4,7 @@ import logging
 import random
 import uuid
 from collections import defaultdict, deque
-from typing import Dict, List, Optional
+from typing import Dict, Iterable, List, Optional
 
 import rstr
 
@@ -365,12 +365,12 @@ class GraphFactory(object):
 
     def create_random_subgraph(
         self,
-        label,
-        max_depth=10,
-        leaf_labels=None,
-        skip_relations=None,
-        all_props=False,
-    ):
+        label: str,
+        max_depth: int = 10,
+        leaf_labels: Optional[Iterable[str]] = None,
+        skip_relations: Optional[Iterable[str]] = None,
+        all_props: bool = False,
+    ) -> List[Node]:
         """
         Generate a randomized graph with root at the given Node `label` type.
 

--- a/psqlgraph/mocks.py
+++ b/psqlgraph/mocks.py
@@ -544,7 +544,7 @@ class GraphFactory(object):
         if label:
             edge_class = self.models.Edge.get_subclass(label)
             if not edge_class:
-                logging.debug("Edge with label {} not found".format(label))
+                logging.warning("Edge with label {} not found".format(label))
             elif (
                 edge_class.__src_class__ == node1.__class__.__name__
                 and edge_class.__dst_class__ == node2.__class__.__name__

--- a/psqlgraph/mocks.py
+++ b/psqlgraph/mocks.py
@@ -558,7 +558,7 @@ class GraphFactory(object):
                 getattr(node2, edge_class.__src_dst_assoc__).append(node1)
                 return
             else:
-                logging.debug(
+                logging.warning(
                     "Edge with label {} not working between nodes {} and {}".format(
                         label, node1.label, node2.label
                     )

--- a/psqlgraph/mocks.py
+++ b/psqlgraph/mocks.py
@@ -523,7 +523,7 @@ class GraphFactory(object):
         return relation in links
 
     def make_association(
-        self, node1: Node, node2: Node, label: Optional[str] = None
+        self, src_node: Node, dst_node: Node, edge_label: Optional[str] = None
     ) -> None:
         """Create an Edge between 2 nodes
 
@@ -537,43 +537,43 @@ class GraphFactory(object):
         Bonus: Label could be added to all edges and will make the lookup faster.
 
         Args:
-            node1: first node of the edge
-            node2: second node of the edge
-            label: label of the edge
+            src_node: first node of the edge
+            dst_node: second node of the edge
+            edge_label: label of the edge
         """
-        if label:
-            edge_class = self.models.Edge.get_subclass(label)
+        if edge_label:
+            edge_class = self.models.Edge.get_subclass(edge_label)
             if not edge_class:
-                logging.warning("Edge with label {} not found".format(label))
+                logging.warning("Edge with label {} not found".format(edge_label))
             elif (
-                edge_class.__src_class__ == node1.__class__.__name__
-                and edge_class.__dst_class__ == node2.__class__.__name__
+                edge_class.__src_class__ == src_node.__class__.__name__
+                and edge_class.__dst_class__ == dst_node.__class__.__name__
             ):
-                getattr(node1, edge_class.__src_dst_assoc__).append(node2)
+                getattr(src_node, edge_class.__src_dst_assoc__).append(dst_node)
                 return
             elif (
-                edge_class.__src_class__ == node2.__class__.__name__
-                and edge_class.__dst_class__ == node1.__class__.__name__
+                edge_class.__src_class__ == dst_node.__class__.__name__
+                and edge_class.__dst_class__ == src_node.__class__.__name__
             ):
-                getattr(node2, edge_class.__src_dst_assoc__).append(node1)
+                getattr(dst_node, edge_class.__src_dst_assoc__).append(src_node)
                 return
             else:
                 logging.warning(
                     "Edge with label {} not working between nodes {} and {}".format(
-                        label, node1.label, node2.label
+                        edge_label, src_node.label, dst_node.label
                     )
                 )
 
         link_found = False
-        for assoc_name, assoc_meta in node1._pg_edges.items():
-            if isinstance(node2, assoc_meta["type"]):
-                getattr(node1, assoc_name).append(node2)
+        for assoc_name, assoc_meta in src_node._pg_edges.items():
+            if isinstance(dst_node, assoc_meta["type"]):
+                getattr(src_node, assoc_name).append(dst_node)
                 link_found = True
                 break
 
         if not link_found:
             logging.debug(
                 "Could not find a direct relation between '{}'<->'{}'".format(
-                    node1.label, node2.label
+                    src_node.label, dst_node.label
                 )
             )

--- a/test/models.py
+++ b/test/models.py
@@ -31,9 +31,8 @@ class FakeDictionary(object):
                     },
                     "ages": {"type": "array", "items": {"type": "integer"}},
                 },
-                "links": [{"name": "foobars"}, {"name": "bars_4"}],
+                "links": [{"name": "foobars"}],
             },
-            "bar": {"properties": {}, "links": [{"name": "foos_5"}],},
             "foo_bar": {"properties": {"bar": {"type": "string"},}, "links": [],},
             "test_default_value": {
                 "properties": {
@@ -45,6 +44,8 @@ class FakeDictionary(object):
                 },
                 "links": [],
             },
+            "circle_1": {"properties": {}, "links": [{"name": "edge_4"}]},
+            "circle_2": {"properties": {}, "links": [{"name": "edge_5"}]},
         }
 
 
@@ -91,20 +92,20 @@ class Edge4(Edge):
 
     __label__ = "edge4"
 
-    __src_class__ = "Foo"
-    __dst_class__ = "Bar"
-    __src_dst_assoc__ = "bars_4"
-    __dst_src_assoc__ = "foos_4"
+    __src_class__ = "Circle1"
+    __dst_class__ = "Circle2"
+    __src_dst_assoc__ = "circle_2a"
+    __dst_src_assoc__ = "circle_1a"
 
 
 class Edge5(Edge):
 
     __label__ = "edge5"
 
-    __src_class__ = "Bar"
-    __dst_class__ = "Foo"
-    __src_dst_assoc__ = "foos_5"
-    __dst_src_assoc__ = "bars_5"
+    __src_class__ = "Circle2"
+    __dst_class__ = "Circle1"
+    __src_dst_assoc__ = "circle_1b"
+    __dst_src_assoc__ = "circle_2b"
 
 
 class TestToFooBarEdge(Edge):
@@ -169,9 +170,16 @@ class Foo(Node):
         self._set_property("ages", value)
 
 
-class Bar(Node):
+class Circle1(Node):
 
-    __label__ = "bar"
+    __label__ = "circle_1"
+
+    _pg_edges = {}
+
+
+class Circle2(Node):
+
+    __label__ = "circle_2"
 
     _pg_edges = {}
 
@@ -216,15 +224,20 @@ Foo._pg_edges.update(
     {
         "foobars": {"backref": "foos", "type": FooBar,},
         "tests": {"backref": "foos", "type": Test,},
-        "bars_4": {"backref": "foos", "type": Bar,},
-        "bars_5": {"backref": "foos", "type": Bar,},
     }
 )
 
-Bar._pg_edges.update(
+Circle1._pg_edges.update(
     {
-        "foos_4": {"backref": "bars", "type": Foo,},
-        "foos_5": {"backref": "bars", "type": Foo,},
+        "circle_2a": {"backref": "bars", "type": Circle2,},
+        "circle_2b": {"backref": "bars", "type": Circle2,},
+    }
+)
+
+Circle2._pg_edges.update(
+    {
+        "circle_1a": {"backref": "bars", "type": Circle1,},
+        "circle_1b": {"backref": "bars", "type": Circle1,},
     }
 )
 

--- a/test/models.py
+++ b/test/models.py
@@ -31,8 +31,9 @@ class FakeDictionary(object):
                     },
                     "ages": {"type": "array", "items": {"type": "integer"}},
                 },
-                "links": [{"name": "foobars"},],
+                "links": [{"name": "foobars"}, {"name": "bars_4"}],
             },
+            "bar": {"properties": {}, "links": [{"name": "foos_5"}],},
             "foo_bar": {"properties": {"bar": {"type": "string"},}, "links": [],},
             "test_default_value": {
                 "properties": {
@@ -82,6 +83,28 @@ class Edge3(Edge):
     __dst_class__ = "FooBar"
     __src_dst_assoc__ = "foobars"
     __dst_src_assoc__ = "foos"
+
+
+# edge4 and edge5 are used to test special case, Foo->Bar and Bar->Foo are both valid
+# edges.
+class Edge4(Edge):
+
+    __label__ = "edge4"
+
+    __src_class__ = "Foo"
+    __dst_class__ = "Bar"
+    __src_dst_assoc__ = "bars_4"
+    __dst_src_assoc__ = "foos_4"
+
+
+class Edge5(Edge):
+
+    __label__ = "edge5"
+
+    __src_class__ = "Bar"
+    __dst_class__ = "Foo"
+    __src_dst_assoc__ = "foos_5"
+    __dst_src_assoc__ = "bars_5"
 
 
 class TestToFooBarEdge(Edge):
@@ -146,6 +169,13 @@ class Foo(Node):
         self._set_property("ages", value)
 
 
+class Bar(Node):
+
+    __label__ = "bar"
+
+    _pg_edges = {}
+
+
 class FooBar(Node):
 
     __label__ = "foo_bar"
@@ -186,6 +216,15 @@ Foo._pg_edges.update(
     {
         "foobars": {"backref": "foos", "type": FooBar,},
         "tests": {"backref": "foos", "type": Test,},
+        "bars_4": {"backref": "foos", "type": Bar,},
+        "bars_5": {"backref": "foos", "type": Bar,},
+    }
+)
+
+Bar._pg_edges.update(
+    {
+        "foos_4": {"backref": "bars", "type": Foo,},
+        "foos_5": {"backref": "bars", "type": Foo,},
     }
 )
 

--- a/test/test_mocks.py
+++ b/test/test_mocks.py
@@ -264,8 +264,14 @@ UUID2 = str(uuid.uuid4())
     ],
 )
 def test_graph_factory_with_ambiguous_edges(
-    gdcmodels, gdcdictionary, src_id, dst_id, edge_label, circle_1_to_2, circle_2_to_1
-):
+    gdcmodels: FakeModels,
+    gdcdictionary: models.FakeDictionary,
+    src_id: str,
+    dst_id: str,
+    edge_label: str,
+    circle_1_to_2: str,
+    circle_2_to_1: str,
+) -> None:
     """Test using label to solve ambiguous edges.
 
     For some node couples, there are 2 edges in opposite directions between them.

--- a/test/test_mocks.py
+++ b/test/test_mocks.py
@@ -269,6 +269,7 @@ def test_graph_factory_with_ambiguous_edges(
     """Test using label to solve ambiguous edges.
 
     For some node couples, there are 2 edges in opposite directions between them.
+    Generating a circle between those 2 nodes.
     In those cases, to solve the relation correctly, we should provide edge label to
     link them.
 

--- a/test/test_mocks.py
+++ b/test/test_mocks.py
@@ -255,16 +255,16 @@ UUID2 = str(uuid.uuid4())
 
 
 @pytest.mark.parametrize(
-    "src_id,dst_id,edge_label,foo_to_bar,bar_to_foo",
+    "src_id,dst_id,edge_label,circle_1_to_2,circle_2_to_1",
     [
-        (UUID1, UUID2, "edge4", "bars_4", "foos_4"),
-        (UUID1, UUID2, "edge5", "bars_5", "foos_5"),
-        (UUID2, UUID1, "edge4", "bars_4", "foos_4"),
-        (UUID2, UUID1, "edge5", "bars_5", "foos_5"),
+        (UUID1, UUID2, "edge4", "circle_2a", "circle_1a",),
+        (UUID1, UUID2, "edge5", "circle_2b", "circle_1b",),
+        (UUID2, UUID1, "edge4", "circle_2a", "circle_1a",),
+        (UUID2, UUID1, "edge5", "circle_2b", "circle_1b",),
     ],
 )
 def test_graph_factory_with_ambiguous_edges(
-    gdcmodels, gdcdictionary, src_id, dst_id, edge_label, foo_to_bar, bar_to_foo
+    gdcmodels, gdcdictionary, src_id, dst_id, edge_label, circle_1_to_2, circle_2_to_1
 ):
     """Test using label to solve ambiguous edges.
 
@@ -286,7 +286,10 @@ def test_graph_factory_with_ambiguous_edges(
     """
     gf = GraphFactory(gdcmodels, gdcdictionary)
 
-    nodes = [{"label": "foo", "node_id": UUID1}, {"label": "bar", "node_id": UUID2}]
+    nodes = [
+        {"label": "circle_1", "node_id": UUID1},
+        {"label": "circle_2", "node_id": UUID2},
+    ]
 
     edges = [
         {"src": src_id, "dst": dst_id, "label": edge_label},
@@ -298,18 +301,18 @@ def test_graph_factory_with_ambiguous_edges(
 
     assert len(created_nodes) == 2
 
-    foos = [n for n in created_nodes if n.label == "foo"]
-    assert len(foos) == 1
-    foo = foos[0]
-    foo_to_bar_assoc = getattr(foo, foo_to_bar)
-    assert len(foo_to_bar_assoc) == 1
-    bars = [n for n in created_nodes if n.label == "bar"]
-    assert len(bars) == 1
-    bar = bars[0]
-    bar_to_foo_assoc = getattr(bar, bar_to_foo)
-    assert len(bar_to_foo_assoc) == 1
-    assert foo_to_bar_assoc[0] == bar
-    assert bar_to_foo_assoc[0] == foo
+    circle_1s = [n for n in created_nodes if n.label == "circle_1"]
+    assert len(circle_1s) == 1
+    circle_1 = circle_1s[0]
+    circle_1_to_2_assic = getattr(circle_1, circle_1_to_2)
+    assert len(circle_1_to_2_assic) == 1
+    circle_2s = [n for n in created_nodes if n.label == "circle_2"]
+    assert len(circle_2s) == 1
+    circle_2 = circle_2s[0]
+    circle_2_to_1_assoc = getattr(circle_2, circle_2_to_1)
+    assert len(circle_2_to_1_assoc) == 1
+    assert circle_1_to_2_assic[0] == circle_2
+    assert circle_2_to_1_assoc[0] == circle_1
 
-    assert len(foo.edges_out + foo.edges_in) == 1
-    assert len(bar.edges_out + bar.edges_in) == 1
+    assert len(circle_1.edges_out + circle_1.edges_in) == 1
+    assert len(circle_2.edges_out + circle_2.edges_in) == 1

--- a/test/test_mocks.py
+++ b/test/test_mocks.py
@@ -281,8 +281,8 @@ def test_graph_factory_with_ambiguous_edges(
         src_id: uuid for edge node
         dst_id: uuid for another edge node
         edge_label: label of edge
-        foo_to_bar: association name from foo to bar
-        bar_to_foo: association name from bar to foo
+        circle_1_to_2: association name from circle_1 to circle_2
+        circle_2_to_1: association name from circle_2 to circle_1
     """
     gf = GraphFactory(gdcmodels, gdcdictionary)
 

--- a/test/test_mocks.py
+++ b/test/test_mocks.py
@@ -266,6 +266,23 @@ UUID2 = str(uuid.uuid4())
 def test_graph_factory_with_ambiguous_edges(
     gdcmodels, gdcdictionary, src_id, dst_id, edge_label, foo_to_bar, bar_to_foo
 ):
+    """Test using label to solve ambiguous edges.
+
+    For some node couples, there are 2 edges in opposite directions between them.
+    In those cases, to solve the relation correctly, we should provide edge label to
+    link them.
+
+    Note: src_id and dst_id was never used to indicate direction of edge.
+
+    Args:
+        gdcmodels: fake models
+        gdcdictionary: fake dictionary
+        src_id: uuid for edge node
+        dst_id: uuid for another edge node
+        edge_label: label of edge
+        foo_to_bar: association name from foo to bar
+        bar_to_foo: association name from bar to foo
+    """
     gf = GraphFactory(gdcmodels, gdcdictionary)
 
     nodes = [{"label": "foo", "node_id": UUID1}, {"label": "bar", "node_id": UUID2}]


### PR DESCRIPTION
fix a bug in mocks.py. 
In biodictionary, there are circles between 2 nodes. Psqlgraph will not be able to solve the edge correctly in this case. 
Add the label of the edge so psqlgraph can solve correctly. 