### PR TITLE
DEV-3250: Standardize & utilize psqlgraph package interface.

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -144,10 +144,10 @@
         "filename": "test/test_mocks.py",
         "hashed_secret": "99ffd88615aaba1c26dbae068b6b6360bd1358a4",
         "is_verified": false,
-        "line_number": 209,
+        "line_number": 208,
         "is_secret": false
       }
     ]
   },
-  "generated_at": "2025-02-10T15:32:03Z"
+  "generated_at": "2025-03-21T01:35:14Z"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ context = "unit tests"
 source = ["psqlgraph"]
 
 [tool.isort]
-known_first_party = ["psqlgraph"]
+known_first_party = ["psqlgraph", "test"]
 line_length = 98
 profile = "black"
 
@@ -69,7 +69,7 @@ junit_logging = "system-out"
 log_cli = true
 log_cli_level = "INFO"
 norecursedirs = [".git", ".tox", "dist", "build", "doc", "docs", "travis"]
-testpaths = ["tests"]
+testpaths = ["test"]
 
 [tool.setuptools_scm]
 local_scheme = "versionista-local-format"

--- a/src/psqlgraph/__init__.py
+++ b/src/psqlgraph/__init__.py
@@ -1,7 +1,22 @@
-from psqlgraph.base import create_all
-from psqlgraph.edge import Edge, PolyEdge
-from psqlgraph.node import Node, PolyNode
+from psqlgraph.base import create_all, drop_all
+from psqlgraph.edge import AbstractEdge, Edge, PolyEdge
+from psqlgraph.node import AbstractNode, Node, PolyNode
 from psqlgraph.psql import PsqlGraphDriver
-from psqlgraph.util import pg_property, sanitize, validate
+from psqlgraph.util import pg_property
 from psqlgraph.voided_edge import VoidedEdge
 from psqlgraph.voided_node import VoidedNode
+
+__all__ = (
+    "AbstractEdge",
+    "AbstractNode",
+    "Edge",
+    "Node",
+    "PolyEdge",
+    "PolyNode",
+    "PsqlGraphDriver",
+    "VoidedEdge",
+    "VoidedNode",
+    "create_all",
+    "drop_all",
+    "pg_property",
+)

--- a/src/psqlgraph/psql.py
+++ b/src/psqlgraph/psql.py
@@ -26,6 +26,8 @@ from psqlgraph.voided_node import VoidedNode
 
 logger = logging.getLogger(__name__)
 
+ENGINE_SCHEME = "postgresql+psycopg2"
+
 
 class PsqlGraphDriver:
 
@@ -106,7 +108,7 @@ class PsqlGraphDriver:
 
         # Create driver engine
         self.engine = sqlalchemy.create_engine(
-            f"postgresql+psycopg2://{user}:{password}@{host}/{database}",
+            f"{ENGINE_SCHEME}://{user}:{password}@{host}/{database}",
             encoding="latin1",
             connect_args=connect_args,
             **kwargs,

--- a/src/psqlgraph/psql.py
+++ b/src/psqlgraph/psql.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import enum
 import logging
 import socket
 from contextlib import contextmanager
@@ -26,7 +27,30 @@ from psqlgraph.voided_node import VoidedNode
 
 logger = logging.getLogger(__name__)
 
-ENGINE_SCHEME = "postgresql+psycopg2"
+
+class PostgresDriver(enum.Enum):
+    """The currently supported postgres drivers for sqlalchemy (1.4/2.0)
+
+    NOTE: Currently psqlgraph only supports PSYCOPG2.
+    """
+
+    PSYCOPG2 = "psycopg2"
+    PSYCOPG = "psycopg"
+    PG8000 = "pg8000"
+    ASYNCPG = "asyncpg"
+
+
+def engine_scheme(driver: PostgresDriver = PostgresDriver.PSYCOPG2) -> str:
+    """Generates the engine scheme for the given driver.
+
+    Args:
+        driver: The driver which the `sqlalchemy.Engine` should use when interacting
+            with the database.
+
+    Returns:
+        the url scheme for connecting to the database e.g. 'postgresql+psycopg2'
+    """
+    return f"postgresql+{driver.value}"
 
 
 class PsqlGraphDriver:
@@ -39,7 +63,7 @@ class PsqlGraphDriver:
         user: str,
         password: str,
         database: str,
-        scheme: str = ENGINE_SCHEME,
+        driver: PostgresDriver = PostgresDriver.PSYCOPG2,
         application_name: str | None = None,
         auto_flush: bool = True,
         connect_args: dict | None = None,
@@ -58,8 +82,8 @@ class PsqlGraphDriver:
             password: The password the driver should use for the given user.
             database: The name of the database backing the graph represented in the
                 package namespace.
-            schema: The scheme to use when making the connection string for connecting
-                to the database via the `sqlalchemy.Engine`.
+            driver: The postgres driver to use when making the connecting for to the
+                database via the `sqlalchemy.Engine`.
             application_name: The name of this application by default will use the host
                 name. See connection_args.
             auto_flush: Defaults to `True`; force all newly created sessions to set
@@ -111,7 +135,7 @@ class PsqlGraphDriver:
 
         # Create driver engine
         self.engine = sqlalchemy.create_engine(
-            f"{scheme}://{user}:{password}@{host}/{database}",
+            f"{engine_scheme(driver)}://{user}:{password}@{host}/{database}",
             encoding="latin1",
             connect_args=connect_args,
             **kwargs,

--- a/src/psqlgraph/psql.py
+++ b/src/psqlgraph/psql.py
@@ -39,6 +39,7 @@ class PsqlGraphDriver:
         user: str,
         password: str,
         database: str,
+        scheme: str = ENGINE_SCHEME,
         application_name: str | None = None,
         auto_flush: bool = True,
         connect_args: dict | None = None,
@@ -57,6 +58,8 @@ class PsqlGraphDriver:
             password: The password the driver should use for the given user.
             database: The name of the database backing the graph represented in the
                 package namespace.
+            schema: The scheme to use when making the connection string for connecting
+                to the database via the `sqlalchemy.Engine`.
             application_name: The name of this application by default will use the host
                 name. See connection_args.
             auto_flush: Defaults to `True`; force all newly created sessions to set
@@ -108,7 +111,7 @@ class PsqlGraphDriver:
 
         # Create driver engine
         self.engine = sqlalchemy.create_engine(
-            f"{ENGINE_SCHEME}://{user}:{password}@{host}/{database}",
+            f"{scheme}://{user}:{password}@{host}/{database}",
             encoding="latin1",
             connect_args=connect_args,
             **kwargs,

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -4,7 +4,6 @@ import unittest
 import pytest
 
 import psqlgraph
-from psqlgraph import Edge, Node
 
 
 class PsqlgraphBaseTest(unittest.TestCase):
@@ -25,14 +24,5 @@ class PsqlgraphBaseTest(unittest.TestCase):
         self._clear_tables()
 
     def _clear_tables(self):
-        conn = self.g.engine.connect()
-        conn.execute("commit")
-        for table in Node().get_subclass_table_names():
-            if table != Node.__tablename__:
-                conn.execute(f"delete from {table}")
-        for table in Edge.get_subclass_table_names():
-            if table != Edge.__tablename__:
-                conn.execute(f"delete from {table}")
-        conn.execute("delete from _voided_nodes")
-        conn.execute("delete from _voided_edges")
-        conn.close()
+        psqlgraph.drop_all(self.g.engine)
+        psqlgraph.create_all(self.g.engine)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,10 +1,11 @@
+import functools
 import os
 import uuid
-from test import models
 
 import pytest
 
 import psqlgraph
+from test import models
 
 
 @pytest.fixture(scope="session")
@@ -21,14 +22,9 @@ def pg_conf():
 def pg_driver(request, pg_conf):
     pg_graph_driver = psqlgraph.PsqlGraphDriver(**pg_conf)
 
-    def drop_all():
-        psqlgraph.base.ORMBase.metadata.drop_all(pg_graph_driver.engine)
-        psqlgraph.base.VoidedBase.metadata.drop_all(pg_graph_driver.engine)
+    request.addfinalizer(functools.partial(psqlgraph.drop_all, pg_graph_driver.engine))
 
-    request.addfinalizer(drop_all)
-
-    drop_all()
-
+    psqlgraph.drop_all(pg_graph_driver.engine)
     psqlgraph.create_all(pg_graph_driver.engine)
 
     return pg_graph_driver

--- a/test/models.py
+++ b/test/models.py
@@ -1,4 +1,4 @@
-from psqlgraph import Edge, Node, pg_property
+import psqlgraph
 
 
 class FakeDictionary:
@@ -63,27 +63,27 @@ class FakeDictionary:
         }
 
 
-class Edge1(Edge):
+class Edge1(psqlgraph.Edge):
 
     __src_class__ = "Test"
     __dst_class__ = "Test"
     __src_dst_assoc__ = "tests"
     __dst_src_assoc__ = "sub_tests"
 
-    @pg_property(str, int)
+    @psqlgraph.pg_property(str, int)
     def test(self, value):
         self._set_property("test", value)
 
-    @pg_property
+    @psqlgraph.pg_property()
     def key1(self, value):
         self._set_property("key1", value)
 
-    @pg_property
+    @psqlgraph.pg_property()
     def key2(self, value):
         self._set_property("key2", value)
 
 
-class Edge2(Edge):
+class Edge2(psqlgraph.Edge):
 
     __label__ = "test_edge_2"
     __src_class__ = "Test"
@@ -92,7 +92,7 @@ class Edge2(Edge):
     __dst_src_assoc__ = "tests"
 
 
-class Edge3(Edge):
+class Edge3(psqlgraph.Edge):
 
     __src_class__ = "Foo"
     __dst_class__ = "FooBar"
@@ -102,7 +102,7 @@ class Edge3(Edge):
 
 # edge4 and edge5 are used to test special case, Foo->Bar and Bar->Foo are both valid
 # edges.
-class Edge4(Edge):
+class Edge4(psqlgraph.Edge):
 
     __label__ = "edge4"
 
@@ -112,7 +112,7 @@ class Edge4(Edge):
     __dst_src_assoc__ = "circle_1a"
 
 
-class Edge5(Edge):
+class Edge5(psqlgraph.Edge):
 
     __label__ = "edge5"
 
@@ -122,7 +122,7 @@ class Edge5(Edge):
     __dst_src_assoc__ = "circle_2b"
 
 
-class TestToFooBarEdge(Edge):
+class TestToFooBarEdge(psqlgraph.Edge):
 
     __src_class__ = "Test"
     __dst_class__ = "FooBar"
@@ -130,98 +130,98 @@ class TestToFooBarEdge(Edge):
     __dst_src_assoc__ = "tests"
 
 
-class Test(Node):
+class Test(psqlgraph.Node):
 
     _pg_edges = {}
 
-    @pg_property
+    @psqlgraph.pg_property()
     def key1(self, value):
         assert isinstance(value, (str, type(None)))
         assert value != "bad_value"
         self._set_property("key1", value)
 
-    @pg_property
+    @psqlgraph.pg_property()
     def key2(self, value):
         self._set_property("key2", value)
 
-    @pg_property
+    @psqlgraph.pg_property()
     def key3(self, value):
         self._set_property("key3", value)
 
-    @pg_property
+    @psqlgraph.pg_property()
     def new_key(self, value):
         self._set_property("new_key", value)
 
-    @pg_property(int, str)
+    @psqlgraph.pg_property(int, str)
     def timestamp(self, value):
         self._set_property("timestamp", value)
 
 
-class Foo(Node):
+class Foo(psqlgraph.Node):
 
     __label__ = "foo"
 
     _pg_edges = {}
 
-    @pg_property
+    @psqlgraph.pg_property()
     def bar(self, value):
         self._set_property("bar", value)
 
-    @pg_property(enum=("allowed_1", "allowed_2"))
+    @psqlgraph.pg_property(enum=("allowed_1", "allowed_2"))
     def baz(self, value):
         self._set_property("baz", value)
 
-    @pg_property(int)
+    @psqlgraph.pg_property(int)
     def fobble(self, value):
         self._set_property("fobble", value)
 
-    @pg_property(list)
+    @psqlgraph.pg_property(list)
     def studies(self, value):
         self._set_property("studies", value)
 
-    @pg_property(list)
+    @psqlgraph.pg_property(list)
     def ages(self, value):
         self._set_property("ages", value)
 
 
-class Circle1(Node):
+class Circle1(psqlgraph.Node):
 
     __label__ = "circle_1"
 
     _pg_edges = {}
 
 
-class Circle2(Node):
+class Circle2(psqlgraph.Node):
 
     __label__ = "circle_2"
 
     _pg_edges = {}
 
 
-class FooBar(Node):
+class FooBar(psqlgraph.Node):
 
     __label__ = "foo_bar"
     __nonnull_properties__ = ["bar"]
 
     _pg_edges = {}
 
-    @pg_property
+    @psqlgraph.pg_property()
     def bar(self, value):
         self._set_property("bar", value)
 
 
-class TestDefaultValue(Node):
+class TestDefaultValue(psqlgraph.Node):
     __label__ = "test_default_value"
 
     _pg_edges = {}
 
     _defaults = {"property_with_default": "open"}
 
-    @pg_property(enum=("open", "submitted", "closed", "legacy"))
+    @psqlgraph.pg_property(enum=("open", "submitted", "closed", "legacy"))
     def property_with_default(self, value):
         self._set_property("property_with_default", value)
 
-    @pg_property
+    @psqlgraph.pg_property()
     def property_without_default(self, value):
         self._set_property("property_without_default", value)
 

--- a/test/setup_test_psqlgraph.py
+++ b/test/setup_test_psqlgraph.py
@@ -5,18 +5,19 @@ Needs to be run as the postgres user.
 
 import argparse
 import logging
-from test import models
 
-from sqlalchemy import create_engine
+import sqlalchemy
 
-from psqlgraph import PsqlGraphDriver, create_all
+import psqlgraph
+from psqlgraph import psql
+from test import models as models
 
 
 def try_drop_test_data(user, database, root_user="postgres", host=""):
 
     print("Dropping old test data")
 
-    engine = create_engine(f"postgresql://{root_user}@{host}/postgres")
+    engine = sqlalchemy.create_engine(f"{psql.ENGINE_SCHEME}://{root_user}@{host}/postgres")
 
     conn = engine.connect()
     conn.execute("commit")
@@ -44,7 +45,7 @@ def setup_database(user, password, database, root_user="postgres", host=""):
 
     try_drop_test_data(user, database)
 
-    engine = create_engine(f"postgresql://{root_user}@{host}/postgres")
+    engine = sqlalchemy.create_engine(f"{psql.ENGINE_SCHEME}://{root_user}@{host}/postgres")
     conn = engine.connect()
     conn.execute("commit")
 
@@ -73,8 +74,8 @@ def create_tables(host, user, password, database):
     """
     print("Creating tables in test database")
 
-    driver = PsqlGraphDriver(host, user, password, database)
-    create_all(driver.engine)
+    driver = psqlgraph.PsqlGraphDriver(host, user, password, database)
+    psqlgraph.create_all(driver.engine)
 
 
 def create_indexes(host, user, password, database):

--- a/test/setup_test_psqlgraph.py
+++ b/test/setup_test_psqlgraph.py
@@ -12,12 +12,14 @@ import psqlgraph
 from psqlgraph import psql
 from test import models as models
 
+ENGINE_SCHEME = psql.engine_scheme(psql.PostgresDriver.PSYCOPG2)
+
 
 def try_drop_test_data(user, database, root_user="postgres", host=""):
 
     print("Dropping old test data")
 
-    engine = sqlalchemy.create_engine(f"{psql.ENGINE_SCHEME}://{root_user}@{host}/postgres")
+    engine = sqlalchemy.create_engine(f"{ENGINE_SCHEME}://{root_user}@{host}/postgres")
 
     conn = engine.connect()
     conn.execute("commit")
@@ -45,7 +47,7 @@ def setup_database(user, password, database, root_user="postgres", host=""):
 
     try_drop_test_data(user, database)
 
-    engine = sqlalchemy.create_engine(f"{psql.ENGINE_SCHEME}://{root_user}@{host}/postgres")
+    engine = sqlalchemy.create_engine(f"{ENGINE_SCHEME}://{root_user}@{host}/postgres")
     conn = engine.connect()
     conn.execute("commit")
 

--- a/test/test_driver_flags.py
+++ b/test/test_driver_flags.py
@@ -8,12 +8,11 @@
    parent no matter what was passed in.
 """
 
-from test import models
-
 import pytest
 from sqlalchemy import exc
 
 import psqlgraph
+from test import models
 
 
 @pytest.fixture(scope="module")

--- a/test/test_extensions.py
+++ b/test/test_extensions.py
@@ -1,8 +1,7 @@
 import pytest
 
+import psqlgraph
 from psqlgraph import ext
-from psqlgraph.edge import AbstractEdge, Edge
-from psqlgraph.node import AbstractNode, Node
 
 
 @pytest.mark.parametrize(
@@ -16,8 +15,8 @@ from psqlgraph.node import AbstractNode, Node
 def test_register_bases(ns, node_cls_name, edge_cls_name):
 
     node_cls, edge_cls = ext.register_base_class(package_namespace=ns)
-    assert issubclass(node_cls, AbstractNode)
-    assert issubclass(edge_cls, AbstractEdge)
+    assert issubclass(node_cls, psqlgraph.AbstractNode)
+    assert issubclass(edge_cls, psqlgraph.AbstractEdge)
 
     assert node_cls.__name__ == node_cls_name
     assert edge_cls.__name__ == edge_cls_name
@@ -34,7 +33,7 @@ def test_bases_cached(ns):
 
 def test_abstract_defaults():
     node_cls = ext.get_abstract_node()
-    assert node_cls == Node
+    assert node_cls == psqlgraph.Node
 
     edge_cls = ext.get_abstract_edge()
-    assert edge_cls == Edge
+    assert edge_cls == psqlgraph.Edge

--- a/test/test_extensions_crud.py
+++ b/test/test_extensions_crud.py
@@ -1,5 +1,5 @@
-from psqlgraph import PsqlGraphDriver, create_all, ext, pg_property
-from psqlgraph.base import drop_all
+import psqlgraph
+from psqlgraph import ext
 
 MdaNode, MdaEdge = ext.register_base_class(package_namespace="mda")
 
@@ -17,7 +17,7 @@ class T2(MdaNode):
 
     _pg_edges = {}
 
-    @pg_property
+    @psqlgraph.pg_property
     def bar(self, value):
         self._set_property("bar", value)
 
@@ -26,19 +26,19 @@ class T1(MdaNode):
 
     _pg_edges = {}
 
-    @pg_property
+    @psqlgraph.pg_property
     def foo(self, value):
         self._set_property("foo", value)
 
 
 def test_create_tables(pg_conf):
 
-    g = PsqlGraphDriver(package_namespace="mda", **pg_conf)
+    g = psqlgraph.PsqlGraphDriver(package_namespace="mda", **pg_conf)
     orm_base = ext.get_orm_base("mda")
 
     # clean out any existing record
-    drop_all(g.engine, base=orm_base)
-    create_all(g.engine, base=orm_base)
+    psqlgraph.drop_all(g.engine, base=orm_base)
+    psqlgraph.create_all(g.engine, base=orm_base)
 
     with g.session_scope() as s:
         # create sample entries

--- a/test/test_mocks.py
+++ b/test/test_mocks.py
@@ -1,14 +1,13 @@
+import collections
 import random
 import re
 import uuid
-from collections import defaultdict
-from test import models
 
 import pytest
 
-from psqlgraph import Edge, Node
-from psqlgraph.exc import PSQLGraphError
-from psqlgraph.mocks import GraphFactory, NodeFactory
+import psqlgraph
+from psqlgraph import exc, mocks
+from test import models
 
 STRING_MATCH = "[a-zA-Z0-9]{32}"
 DATE_MATCH = "^[0-9]{4}-[0-9]{2}-[0-9]{2}T00:00:00"
@@ -16,12 +15,12 @@ DATE_MATCH = "^[0-9]{4}-[0-9]{2}-[0-9]{2}T00:00:00"
 
 class FakeModels:
     def __init__(self):
-        self.Node = Node
+        self.Node = psqlgraph.Node
         self.Test = models.Test
         self.Foo = models.Foo
         self.FooBar = models.FooBar
 
-        self.Edge = Edge
+        self.Edge = psqlgraph.Edge
 
 
 @pytest.fixture(scope="session")
@@ -36,7 +35,7 @@ def gdcdictionary():
 
 @pytest.fixture
 def node_factory(gdcmodels, gdcdictionary):
-    return NodeFactory(gdcmodels, gdcdictionary.schema)
+    return mocks.NodeFactory(gdcmodels, gdcdictionary.schema)
 
 
 @pytest.fixture
@@ -79,7 +78,7 @@ def test_node_factory_all_props(node_factory, label, validator):
     validator(node)
 
 
-def test_node_factory_sets_required_for_test_node(node_factory: NodeFactory) -> None:
+def test_node_factory_sets_required_for_test_node(node_factory: mocks.NodeFactory) -> None:
     test_node = node_factory.create("test", override={"key2": "something good"})
     assert re.match(STRING_MATCH, test_node.key1)
     assert all(getattr(test_node, key) is None for key in ["key3", "new_key", "timestamp"])
@@ -92,14 +91,14 @@ def test_node_factory_doesnt_set_any_props(node_factory):
 
 
 def test_init_graph_factory(gdcmodels, gdcdictionary):
-    _ = GraphFactory(gdcmodels, gdcdictionary)
+    _ = mocks.GraphFactory(gdcmodels, gdcdictionary)
 
 
 def test_graph_factory__strict_with_invalid_edge(
     gdcmodels: FakeModels, gdcdictionary: models.FakeDictionary
 ) -> None:
     """Confirm invalid edges raises exception when strict is set to True."""
-    gf = GraphFactory(gdcmodels, gdcdictionary)
+    gf = mocks.GraphFactory(gdcmodels, gdcdictionary)
 
     foobar_uuids = [str(uuid.uuid4())]
     foo_uuids = [str(uuid.uuid4()), str(uuid.uuid4())]
@@ -124,7 +123,7 @@ def test_graph_factory__strict_with_invalid_edge(
         {"src": foo_uuids[1], "dst": foobar_uuids[0]},  # f1 -> fb0
     ]
 
-    with pytest.raises(PSQLGraphError):
+    with pytest.raises(exc.PSQLGraphError):
         gf.create_from_nodes_and_edges(
             nodes=nodes, edges=edges, unique_key="node_id", strict=True
         )
@@ -134,7 +133,7 @@ def test_graph_factory_with_nodes_and_edges(
     gdcmodels: FakeModels, gdcdictionary: models.FakeDictionary
 ) -> None:
     """Test GraphFactory can successfully create nodes and edges."""
-    gf = GraphFactory(gdcmodels, gdcdictionary)
+    gf = mocks.GraphFactory(gdcmodels, gdcdictionary)
 
     foobar_uuids = [str(uuid.uuid4())]
     foo_uuids = [str(uuid.uuid4()), str(uuid.uuid4())]
@@ -160,7 +159,7 @@ def test_graph_factory_with_nodes_and_edges(
 
     created_nodes = gf.create_from_nodes_and_edges(nodes=nodes, edges=edges, unique_key="node_id")
 
-    expected_adjacency = defaultdict(set)
+    expected_adjacency = collections.defaultdict(set)
     for edge_info in edges:
         if edge_info["dst"] == foobar_uuids[0] and edge_info["src"] == test_uuids[0]:
             # This edge shouldn't exist
@@ -183,7 +182,7 @@ def test_graph_factory_with_nodes_and_edges(
 def assert_all_node_types_created_once(nodes):
     # since random.randrange was patched, it's guaranteed that all children
     # will be visited, so we expect 3 nodes 1 for each type
-    type_counts = defaultdict(int)
+    type_counts = collections.defaultdict(int)
     for n in nodes:
         type_counts[n.label] += 1
 
@@ -193,7 +192,7 @@ def assert_all_node_types_created_once(nodes):
 
 
 def test_graph_factory_random_subgraph(gdcmodels, gdcdictionary, patched_randrange):
-    gf = GraphFactory(gdcmodels, gdcdictionary)
+    gf = mocks.GraphFactory(gdcmodels, gdcdictionary)
 
     nodes = gf.create_random_subgraph("foo_bar")
 
@@ -210,13 +209,13 @@ def test_graph_factory_with_globals(gdcmodels, gdcdictionary, patched_randrange)
         }
     }
 
-    gf = GraphFactory(gdcmodels, gdcdictionary, graph_globals=graph_globals)
+    gf = mocks.GraphFactory(gdcmodels, gdcdictionary, graph_globals=graph_globals)
 
     nodes = gf.create_random_subgraph("foo_bar", all_props=True)
 
     assert_all_node_types_created_once(nodes)
 
-    prop_counts = defaultdict(int)
+    prop_counts = collections.defaultdict(int)
     for n in nodes:
         items = (
             (key, tuple(value) if isinstance(value, list) else value)
@@ -243,7 +242,7 @@ def test_graph_factory_with_override_globals(gdcmodels, gdcdictionary):
         }
     }
 
-    gf = GraphFactory(gdcmodels, gdcdictionary, graph_globals=graph_globals)
+    gf = mocks.GraphFactory(gdcmodels, gdcdictionary, graph_globals=graph_globals)
 
     nodes = [
         dict(label="foo", node_id="id_1", studies=["N/A", "STUDY0"]),
@@ -352,7 +351,7 @@ def test_graph_factory_with_ambiguous_edges(
         circle_1_to_2: association name from circle_1 to circle_2
         circle_2_to_1: association name from circle_2 to circle_1
     """
-    gf = GraphFactory(gdcmodels, gdcdictionary)
+    gf = mocks.GraphFactory(gdcmodels, gdcdictionary)
 
     nodes = [
         {"label": "circle_1", "node_id": UUID1},

--- a/test/test_mocks.py
+++ b/test/test_mocks.py
@@ -6,11 +6,11 @@ import uuid
 import pytest
 
 import psqlgraph
-from psqlgraph import exc, mocks
+from psqlgraph import exc, hydrator
 from test import models
 
-STRING_MATCH = "[a-zA-Z0-9]{32}"
-DATE_MATCH = "^[0-9]{4}-[0-9]{2}-[0-9]{2}T00:00:00"
+STRING_MATCH = r"[a-zA-Z0-9]{32}"
+DATE_MATCH = r"^[0-9]{4}-[0-9]{2}-[0-9]{2}T00:00:00"
 
 
 class FakeModels:
@@ -35,7 +35,7 @@ def gdcdictionary():
 
 @pytest.fixture
 def node_factory(gdcmodels, gdcdictionary):
-    return mocks.NodeFactory(gdcmodels, gdcdictionary.schema)
+    return hydrator.NodeFactory(gdcmodels, gdcdictionary.schema)
 
 
 @pytest.fixture
@@ -78,7 +78,7 @@ def test_node_factory_all_props(node_factory, label, validator):
     validator(node)
 
 
-def test_node_factory_sets_required_for_test_node(node_factory: mocks.NodeFactory) -> None:
+def test_node_factory_sets_required_for_test_node(node_factory: hydrator.NodeFactory) -> None:
     test_node = node_factory.create("test", override={"key2": "something good"})
     assert re.match(STRING_MATCH, test_node.key1)
     assert all(getattr(test_node, key) is None for key in ["key3", "new_key", "timestamp"])
@@ -91,14 +91,14 @@ def test_node_factory_doesnt_set_any_props(node_factory):
 
 
 def test_init_graph_factory(gdcmodels, gdcdictionary):
-    _ = mocks.GraphFactory(gdcmodels, gdcdictionary)
+    _ = hydrator.GraphFactory(gdcmodels, gdcdictionary)
 
 
 def test_graph_factory__strict_with_invalid_edge(
     gdcmodels: FakeModels, gdcdictionary: models.FakeDictionary
 ) -> None:
     """Confirm invalid edges raises exception when strict is set to True."""
-    gf = mocks.GraphFactory(gdcmodels, gdcdictionary)
+    gf = hydrator.GraphFactory(gdcmodels, gdcdictionary)
 
     foobar_uuids = [str(uuid.uuid4())]
     foo_uuids = [str(uuid.uuid4()), str(uuid.uuid4())]
@@ -133,7 +133,7 @@ def test_graph_factory_with_nodes_and_edges(
     gdcmodels: FakeModels, gdcdictionary: models.FakeDictionary
 ) -> None:
     """Test GraphFactory can successfully create nodes and edges."""
-    gf = mocks.GraphFactory(gdcmodels, gdcdictionary)
+    gf = hydrator.GraphFactory(gdcmodels, gdcdictionary)
 
     foobar_uuids = [str(uuid.uuid4())]
     foo_uuids = [str(uuid.uuid4()), str(uuid.uuid4())]
@@ -192,7 +192,7 @@ def assert_all_node_types_created_once(nodes):
 
 
 def test_graph_factory_random_subgraph(gdcmodels, gdcdictionary, patched_randrange):
-    gf = mocks.GraphFactory(gdcmodels, gdcdictionary)
+    gf = hydrator.GraphFactory(gdcmodels, gdcdictionary)
 
     nodes = gf.create_random_subgraph("foo_bar")
 
@@ -209,7 +209,7 @@ def test_graph_factory_with_globals(gdcmodels, gdcdictionary, patched_randrange)
         }
     }
 
-    gf = mocks.GraphFactory(gdcmodels, gdcdictionary, graph_globals=graph_globals)
+    gf = hydrator.GraphFactory(gdcmodels, gdcdictionary, graph_globals=graph_globals)
 
     nodes = gf.create_random_subgraph("foo_bar", all_props=True)
 
@@ -242,7 +242,7 @@ def test_graph_factory_with_override_globals(gdcmodels, gdcdictionary):
         }
     }
 
-    gf = mocks.GraphFactory(gdcmodels, gdcdictionary, graph_globals=graph_globals)
+    gf = hydrator.GraphFactory(gdcmodels, gdcdictionary, graph_globals=graph_globals)
 
     nodes = [
         dict(label="foo", node_id="id_1", studies=["N/A", "STUDY0"]),
@@ -351,7 +351,7 @@ def test_graph_factory_with_ambiguous_edges(
         circle_1_to_2: association name from circle_1 to circle_2
         circle_2_to_1: association name from circle_2 to circle_1
     """
-    gf = mocks.GraphFactory(gdcmodels, gdcdictionary)
+    gf = hydrator.GraphFactory(gdcmodels, gdcdictionary)
 
     nodes = [
         {"label": "circle_1", "node_id": UUID1},

--- a/test/test_psqlgraph.py
+++ b/test/test_psqlgraph.py
@@ -1,38 +1,33 @@
+import copy
+import datetime
 import random
 import unittest
 import uuid
-from copy import deepcopy
-from datetime import datetime
-from multiprocessing import Process
 
-# We have to import models here, even if we don't use them
-from test import PsqlgraphBaseTest, models
+from sqlalchemy import exc
 
-from sqlalchemy.exc import IntegrityError
-
-from psqlgraph import Edge, Node
-from psqlgraph import PolyEdge as PsqlEdge
-from psqlgraph import PolyNode
-from psqlgraph import PolyNode as PsqlNode
-from psqlgraph import VoidedEdge, sanitize
+import psqlgraph
+import test
+from psqlgraph import util
+from test import models
 
 
 def timestamp():
-    return str(datetime.now())
+    return str(datetime.datetime.now())
 
 
-class TestPsqlGraphDriver(PsqlgraphBaseTest):
+class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
     def tearDown(self):
         self._clear_tables()
 
     def test_getitem(self):
         """Test that indexing nodes/edges accesses their properties"""
-        node = PolyNode(node_id=str(uuid.uuid4()), label="foo", properties={"bar": 1})
+        node = psqlgraph.PolyNode(node_id=str(uuid.uuid4()), label="foo", properties={"bar": 1})
         self.assertEqual(node["bar"], 1)
 
     def test_setitem(self):
         """Test that indexing nodes/edges accesses their properties"""
-        node = PolyNode(node_id=str(uuid.uuid4()), label="foo", properties={"bar": 1})
+        node = psqlgraph.PolyNode(node_id=str(uuid.uuid4()), label="foo", properties={"bar": 1})
         node["bar"] = 2
         self.assertEqual(node["bar"], 2)
         edge = models.Edge1(src_id=None, dst_id=None)
@@ -42,7 +37,7 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
     def test_long_ints_roundtrip(self):
         """Test that integers that only fit in 26 bits round trip correctly."""
         with self.g.session_scope():
-            node = PolyNode(
+            node = psqlgraph.PolyNode(
                 node_id=str(uuid.uuid4()),
                 label="foo",
                 properties={"bar": 9223372036854775808},
@@ -171,7 +166,7 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
         print("-- committed B")
 
         # Merge properties
-        merged = deepcopy(propertiesA)
+        merged = copy.deepcopy(propertiesA)
         merged.update(propertiesB)
 
         if not given_id:
@@ -182,7 +177,7 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
                 node = self.g.node_lookup_one(node_id)
                 self.assertEqual(merged, node.properties)
                 voided_node = self.g.node_lookup(node_id, voided=True).one()
-                voided_props = sanitize(propertiesA)
+                voided_props = util.sanitize(propertiesA)
                 self.assertEqual(voided_props, voided_node.properties)
             self.verify_node_count(2, node_id=node_id, voided=True)
 
@@ -242,7 +237,7 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
 
         node_id = str(uuid.uuid4())
 
-        system_annotationsA = sanitize({"key1": None, "key2": 2, "key3": timestamp()})
+        system_annotationsA = util.sanitize({"key1": None, "key2": 2, "key3": timestamp()})
         node = self.g.node_merge(
             node_id=node_id, label="test", system_annotations=system_annotationsA
         )
@@ -259,9 +254,9 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
 
         node_id = str(uuid.uuid4())
 
-        props = sanitize({"key1": None, "key2": 2})
+        props = util.sanitize({"key1": None, "key2": 2})
         with self.g.session_scope():
-            node = PolyNode(node_id, "test", properties=props)
+            node = psqlgraph.PolyNode(node_id, "test", properties=props)
         test_string = "This is a test"
         node.properties["key1"] = test_string
         with self.g.session_scope() as session:
@@ -284,27 +279,29 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
         node_id = str(uuid.uuid4()) if not given_id else given_id
 
         # Add first node
-        system_annotationsA = sanitize({"key1": None, "key2": 2, "key3": timestamp()})
+        system_annotationsA = util.sanitize({"key1": None, "key2": 2, "key3": timestamp()})
         self.g.node_merge(node_id=node_id, label="test", system_annotations=system_annotationsA)
 
         # Add second node
-        system_annotationsB = sanitize({"key1": None, "new_key": 2, "timestamp": timestamp()})
+        system_annotationsB = util.sanitize(
+            {"key1": None, "new_key": 2, "timestamp": timestamp()}
+        )
         self.g.node_merge(node_id=node_id, label="test", system_annotations=system_annotationsB)
 
         # Merge system_annotations
-        merged = deepcopy(system_annotationsA)
+        merged = copy.deepcopy(system_annotationsA)
         merged.update(system_annotationsB)
 
         # if this is not part of another test, check the count
         if not given_id:
             with self.g.session_scope():
                 node = self.g.node_lookup_one(node_id)
-            print("merged:", sanitize(merged))
-            print("node:", sanitize(node.system_annotations))
-            self.assertEqual(sanitize(merged), sanitize(node.system_annotations))
+            print("merged:", util.sanitize(merged))
+            print("node:", util.sanitize(node.system_annotations))
+            self.assertEqual(util.sanitize(merged), util.sanitize(node.system_annotations))
 
             nodes = list(self.verify_node_count(2, node_id=node_id, voided=True))
-            self.assertEqual(sanitize(system_annotationsA), nodes[1].system_annotations)
+            self.assertEqual(util.sanitize(system_annotationsA), nodes[1].system_annotations)
 
         return merged
 
@@ -313,7 +310,7 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
         node_id = str(uuid.uuid4())
 
         # add first node
-        propertiesA = sanitize(
+        propertiesA = util.sanitize(
             {
                 "key1": None,
                 "key2": 1,
@@ -322,7 +319,7 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
                 "new_key": None,
             }
         )
-        system_annotationsA = sanitize({"key1": None, "key2": 2, "key3": timestamp()})
+        system_annotationsA = util.sanitize({"key1": None, "key2": 2, "key3": timestamp()})
         self.g.node_merge(
             node_id=node_id,
             label="test",
@@ -331,7 +328,9 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
         )
 
         dst = self.g.node_merge(node_id=str(uuid.uuid4()), label="test")
-        edge1 = self.g.edge_insert(PsqlEdge(src_id=node_id, dst_id=dst.node_id, label="edge1"))
+        edge1 = self.g.edge_insert(
+            psqlgraph.PolyEdge(src_id=node_id, dst_id=dst.node_id, label="edge1")
+        )
 
         with self.g.session_scope():
             node = self.g.node_lookup_one(node_id)
@@ -349,7 +348,7 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
         """Test node creation from json"""
         node_id = str(uuid.uuid4())
 
-        propertiesA = sanitize(
+        propertiesA = util.sanitize(
             {
                 "key1": None,
                 "key2": 1,
@@ -359,7 +358,7 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
             }
         )
 
-        system_annotationsA = sanitize({"key1": None, "key2": 2, "key3": timestamp()})
+        system_annotationsA = util.sanitize({"key1": None, "key2": 2, "key3": timestamp()})
 
         node_json = {
             "node_id": node_id,
@@ -371,7 +370,7 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
             "edges_in": [],
         }
 
-        node = Node.from_json(node_json)
+        node = psqlgraph.Node.from_json(node_json)
 
         with self.g.session_scope() as s:
             s.merge(node)
@@ -386,7 +385,7 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
         node_id = str(uuid.uuid4())
 
         # add first node
-        propertiesA = sanitize(
+        propertiesA = util.sanitize(
             {
                 "key1": None,
                 "key2": 1,
@@ -395,7 +394,7 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
                 "new_key": None,
             }
         )
-        system_annotationsA = sanitize({"key1": None, "key2": 2, "key3": timestamp()})
+        system_annotationsA = util.sanitize({"key1": None, "key2": 2, "key3": timestamp()})
         self.g.node_merge(
             node_id=node_id,
             label="test",
@@ -404,14 +403,16 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
         )
 
         dst = self.g.node_merge(node_id=str(uuid.uuid4()), label="test")
-        edge1 = self.g.edge_insert(PsqlEdge(src_id=node_id, dst_id=dst.node_id, label="edge1"))
+        edge1 = self.g.edge_insert(
+            psqlgraph.PolyEdge(src_id=node_id, dst_id=dst.node_id, label="edge1")
+        )
 
         with self.g.session_scope():
             node = self.g.node_lookup_one(node_id)
 
             node_json = node.to_json()
 
-            new_node = Node.from_json(node_json)
+            new_node = psqlgraph.Node.from_json(node_json)
             self.assertDictEqual(new_node.props, node.props)
             self.assertDictEqual(new_node.sysan, node.sysan)
             self.assertEqual(new_node.node_id, node_id)
@@ -435,8 +436,8 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
         self.g.node_merge(node_id=tempid, label="test", properties=propertiesA)
 
         propertiesB = {"key1": None, "key2": 2, "key3": timestamp()}
-        with self.assertRaises(IntegrityError):
-            bad_node = PolyNode(
+        with self.assertRaises(exc.IntegrityError):
+            bad_node = psqlgraph.PolyNode(
                 node_id=tempid,
                 system_annotations={},
                 acl=[],
@@ -490,7 +491,7 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
             self.verify_node_count(REPEAT_COUNT * 2, node_id=node_id, voided=True)
             with self.g.session_scope():
                 node = self.g.node_lookup_one(node_id)
-            self.assertEqual(sanitize(annotations), sanitize(node.system_annotations))
+            self.assertEqual(util.sanitize(annotations), util.sanitize(node.system_annotations))
 
     def test_sessioned_node_update(self):
         """Test repeated update of a sessioned node
@@ -521,34 +522,6 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
                 properties[node.node_id],
                 node.properties,
             )
-
-    @unittest.skip("not implemented")
-    def test_concurrent_node_update_by_id(self):
-        """Test concurrent node updating by ID
-
-        Test that insertion of nodes is thread-safe and that retries succeed
-        eventually
-        """
-
-        process_count = 2
-        tempid = str(uuid.uuid4())
-        processes = []
-
-        for tally in range(process_count):
-            processes.append(
-                Process(
-                    target=self.test_repeated_node_update_properties_by_id,
-                    kwargs={"given_id": tempid},
-                )
-            )
-
-        for p in processes:
-            p.start()
-
-        for p in processes:
-            p.join()
-
-        self.verify_node_count(process_count * self.REPEAT_COUNT * 2, tempid, voided=True)
 
     def test_node_clobber(self):
         """Test that clobbering a node replaces all of its properties"""
@@ -642,23 +615,11 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
 
         self.assertRaises(
             AttributeError,
-            PsqlEdge,
+            psqlgraph.PolyEdge,
             str(uuid.uuid4()),
             str(uuid.uuid4),
             None,
         )
-
-    @unittest.skip("not implemented")
-    def test_edges_have_unique_ids(self):
-        """Test that generated edge ids are unique"""
-        src_id = str(uuid.uuid4())
-        dst_id = str(uuid.uuid4())
-        self.g.node_merge(node_id=src_id, label="test")
-        self.g.node_merge(node_id=dst_id, label="test")
-
-        edge1 = self.g.edge_insert(PsqlEdge(src_id=src_id, dst_id=dst_id, label="edge1"))
-        edge2 = self.g.edge_insert(PsqlEdge(src_id=src_id, dst_id=dst_id, label="edge2"))
-        self.assertNotEqual(edge1.edge_id, edge2.edge_id)
 
     def test_edge_insert_and_lookup(self):
         """Test edge creation and lookup by dst_id, src_id, dst_id and src_id"""
@@ -668,7 +629,9 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
             self.g.node_merge(node_id=src_id, label="test")
             self.g.node_merge(node_id=dst_id, label="test")
 
-            edge = self.g.edge_insert(PsqlEdge(src_id=src_id, dst_id=dst_id, label="edge1"))
+            edge = self.g.edge_insert(
+                psqlgraph.PolyEdge(src_id=src_id, dst_id=dst_id, label="edge1")
+            )
             self.g.edge_update(edge, properties={"test": None})
             self.g.edge_update(edge, properties={"test": 2})
 
@@ -694,10 +657,12 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
             dst_id = str(uuid.uuid4())
             self.g.node_merge(node_id=src_id, label="test")
             self.g.node_merge(node_id=dst_id, label="test")
-            edge = self.g.edge_insert(PsqlEdge(src_id=src_id, dst_id=dst_id, label="edge1"))
+            edge = self.g.edge_insert(
+                psqlgraph.PolyEdge(src_id=src_id, dst_id=dst_id, label="edge1")
+            )
         with self.g.session_scope():
             self.g.edge_update(edge, properties={"test": 3})
-            voided_edge = self.g.edges(VoidedEdge).one()
+            voided_edge = self.g.edges(psqlgraph.VoidedEdge).one()
             self.assertEqual(edge.property_template(), voided_edge.properties)
 
     def test_edge_insert_and_lookup_properties(self):
@@ -709,7 +674,7 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
             self.g.node_merge(node_id=src_id, label="test")
             self.g.node_merge(node_id=dst_id, label="test")
             self.g.edge_insert(
-                PsqlEdge(src_id=src_id, dst_id=dst_id, properties=props, label="edge1")
+                psqlgraph.PolyEdge(src_id=src_id, dst_id=dst_id, properties=props, label="edge1")
             )
             edge = self.g.edge_lookup_one(src_id=src_id, dst_id=dst_id)
             self.assertEqual(edge.src_id, src_id)
@@ -731,7 +696,9 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
             dst_ids = [str(uuid.uuid4()) for i in range(leaf_count)]
             for dst_id in dst_ids:
                 self.g.node_merge(node_id=dst_id, label="test")
-                self.g.edge_insert(PsqlEdge(src_id=src_id, dst_id=dst_id, label="edge1"))
+                self.g.edge_insert(
+                    psqlgraph.PolyEdge(src_id=src_id, dst_id=dst_id, label="edge1")
+                )
 
             edge_ids = [e.dst_id for e in self.g.edge_lookup(src_id=src_id)]
             self.assertEqual(len(set(edge_ids)), leaf_count)
@@ -746,7 +713,7 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
         with self.g.session_scope():
             nid1 = self.g.node_merge(node_id=str(uuid.uuid4()), label="test").node_id
             nid2 = self.g.node_merge(node_id=str(uuid.uuid4()), label="test").node_id
-            self.g.edge_insert(PsqlEdge(src_id=nid1, dst_id=nid2, label="edge1"))
+            self.g.edge_insert(psqlgraph.PolyEdge(src_id=nid1, dst_id=nid2, label="edge1"))
             self.g.edge_lookup(label="edge1", src_id=nid1, dst_id=nid2).one()
 
     def test_edge_to_json(self):
@@ -758,7 +725,7 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
             dst = self.g.node_merge(node_id=dst_id, label="test")
 
             edge = self.g.edge_insert(
-                PsqlEdge(src_id=src_id, dst_id=dst_id, label="edge1"), session=session
+                psqlgraph.PolyEdge(src_id=src_id, dst_id=dst_id, label="edge1"), session=session
             )
 
             expected_json = {
@@ -780,7 +747,7 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
         src = self.g.node_merge(node_id=src_id, label="test")
         dst = self.g.node_merge(node_id=dst_id, label="test")
 
-        self.assertIs(Edge.get_unique_subclass("test", "edge1", "test"), models.Edge1)
+        self.assertIs(psqlgraph.Edge.get_unique_subclass("test", "edge1", "test"), models.Edge1)
 
     def test_edge_from_json(self):
         """Test edge creation from json"""
@@ -801,7 +768,7 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
                 "system_annotations": {},
             }
 
-            edge = Edge.from_json(edge_json)
+            edge = psqlgraph.Edge.from_json(edge_json)
 
             self.assertEqual(edge.acl, [])
             self.assertEqual(edge.label, "edge1")
@@ -817,11 +784,13 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
             src = self.g.node_merge(node_id=src_id, label="test")
             dst = self.g.node_merge(node_id=dst_id, label="test")
 
-            edge = self.g.edge_insert(PsqlEdge(src_id=src_id, dst_id=dst_id, label="edge1"))
+            edge = self.g.edge_insert(
+                psqlgraph.PolyEdge(src_id=src_id, dst_id=dst_id, label="edge1")
+            )
 
             edge_json = edge.to_json()
 
-            new_edge = Edge.from_json(edge_json)
+            new_edge = psqlgraph.Edge.from_json(edge_json)
 
             self.assertEqual(new_edge.src_id, edge.src_id)
             self.assertEqual(new_edge.dst_id, edge.dst_id)
@@ -849,7 +818,7 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
                 for dst_id in dst_ids:
                     node = self.g.node_lookup_one(node_id=dst_id)
                     self.g.edge_insert(
-                        PsqlEdge(src_id=src_id, dst_id=node.node_id, label="edge1"),
+                        psqlgraph.PolyEdge(src_id=src_id, dst_id=node.node_id, label="edge1"),
                         session=session,
                     )
 
@@ -874,7 +843,9 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
             # Create nodes and link them to source
             for dst_id in dst_ids:
                 self.g.node_merge(node_id=dst_id, label="test")
-                self.g.edge_insert(PsqlEdge(src_id=src_id, dst_id=dst_id, label="edge1"))
+                self.g.edge_insert(
+                    psqlgraph.PolyEdge(src_id=src_id, dst_id=dst_id, label="edge1")
+                )
 
             # Verify that the edges there are correct
             for dst_id in dst_ids:
@@ -931,7 +902,7 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
                 self.g.node_merge(src_id, label="test")
                 self.g.node_merge(dst_id, label="test")
                 self.g.edge_insert(
-                    PsqlEdge(
+                    psqlgraph.PolyEdge(
                         src_id=src_id,
                         dst_id=dst_id,
                         label="edge1",
@@ -956,7 +927,9 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
             for i in range(5):
                 node_id = str(uuid.uuid4())
                 self.g.node_merge(node_id=node_id, label=f"test")
-                self.g.edge_insert(PsqlEdge(src_id=parent_id, dst_id=node_id, label="edge1"))
+                self.g.edge_insert(
+                    psqlgraph.PolyEdge(src_id=parent_id, dst_id=node_id, label="edge1")
+                )
                 if level < 2:
                     self._create_subtree(node_id, level + 1)
 
@@ -983,7 +956,7 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
             self.g.node_merge(node_id=src_id, label="test")
             self.g.node_merge(node_id=dst_id, label="test")
             self.g.node_merge(node_id=foo_id, label="foo")
-            self.g.edge_insert(PsqlEdge(src_id=src_id, dst_id=dst_id, label="edge1"))
+            self.g.edge_insert(psqlgraph.PolyEdge(src_id=src_id, dst_id=dst_id, label="edge1"))
             self.g.edge_insert(models.Edge2(src_id, foo_id))
             s.commit()
             self.assertEqual(len(list(self.g.edge_lookup(src_id=src_id, dst_id=dst_id))), 1)
@@ -997,7 +970,7 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
     def test_simple_automatic_session(self):
         idA = str(uuid.uuid4())
         with self.g.session_scope():
-            self.g.node_insert(PsqlNode(idA, "test"))
+            self.g.node_insert(psqlgraph.PolyNode(idA, "test"))
         with self.g.session_scope():
             self.g.node_lookup(idA).one()
 
@@ -1010,10 +983,10 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
 
         """
         nid = str(uuid.uuid4())
-        with self.assertRaises(IntegrityError):
+        with self.assertRaises(exc.IntegrityError):
             with self.g.session_scope():
-                self.g.node_insert(PsqlNode(nid, "test"))
-                self.g.node_insert(PsqlNode(nid, "test"))
+                self.g.node_insert(psqlgraph.PolyNode(nid, "test"))
+                self.g.node_insert(psqlgraph.PolyNode(nid, "test"))
         with self.g.session_scope():
             self.assertEqual(len(list(self.g.node_lookup(nid).all())), 0)
 
@@ -1027,8 +1000,8 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
 
         """
         nid = str(uuid.uuid4())
-        self.g.node_insert(PsqlNode(nid, "test"))
-        self.assertRaises(IntegrityError, self.g.node_insert, PsqlNode(nid, "test"))
+        self.g.node_insert(psqlgraph.PolyNode(nid, "test"))
+        self.assertRaises(exc.IntegrityError, self.g.node_insert, psqlgraph.PolyNode(nid, "test"))
         with self.g.session_scope():
             self.assertEqual(self.g.node_lookup(nid).one().label, "test")
         self.assertFalse(self.g.has_session())
@@ -1041,11 +1014,11 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
 
         """
         nid = str(uuid.uuid4())
-        with self.assertRaises(IntegrityError):
+        with self.assertRaises(exc.IntegrityError):
             with self.g.session_scope():
-                self.g.node_insert(PsqlNode(nid, "test"))
+                self.g.node_insert(psqlgraph.PolyNode(nid, "test"))
                 with self.g.session_scope(can_inherit=False):
-                    self.g.node_insert(PsqlNode(nid, "test"))
+                    self.g.node_insert(psqlgraph.PolyNode(nid, "test"))
         with self.g.session_scope():
             self.assertEqual(self.g.node_lookup(nid).one().label, "test")
         self.assertFalse(self.g.has_session())
@@ -1060,12 +1033,12 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
         """
         id1 = str(uuid.uuid4())
         id2 = str(uuid.uuid4())
-        self.g.node_insert(PsqlNode(id1, "foo"))
+        self.g.node_insert(psqlgraph.PolyNode(id1, "foo"))
         with self.g.session_scope():
-            self.g.node_insert(PsqlNode(id2, "test"))
-            with self.assertRaises(IntegrityError):
+            self.g.node_insert(psqlgraph.PolyNode(id2, "test"))
+            with self.assertRaises(exc.IntegrityError):
                 with self.g.session_scope(can_inherit=False):
-                    self.g.node_insert(PsqlNode(id1, "foo"))
+                    self.g.node_insert(psqlgraph.PolyNode(id1, "foo"))
         with self.g.session_scope():
             self.assertEqual(self.g.node_lookup(id2).one().label, "test")
         self.assertFalse(self.g.has_session())
@@ -1079,13 +1052,13 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
 
         """
         id1, id2, id3 = str(uuid.uuid4()), str(uuid.uuid4()), str(uuid.uuid4())
-        self.g.node_insert(PsqlNode(id1, "foo"))
+        self.g.node_insert(psqlgraph.PolyNode(id1, "foo"))
         with self.g.session_scope():
-            self.g.node_insert(PsqlNode(id2, "test"))
-            with self.assertRaises(IntegrityError):
+            self.g.node_insert(psqlgraph.PolyNode(id2, "test"))
+            with self.assertRaises(exc.IntegrityError):
                 with self.g.session_scope(can_inherit=False):
-                    self.g.node_insert(PsqlNode(id1, "foo"))
-                    self.g.node_insert(PsqlNode(id3, "foo"))
+                    self.g.node_insert(psqlgraph.PolyNode(id1, "foo"))
+                    self.g.node_insert(psqlgraph.PolyNode(id3, "foo"))
         with self.g.session_scope():
             self.assertEqual(self.g.node_lookup(id2).one().label, "test")
             self.assertEqual(self.g.node_lookup(id3).count(), 0)
@@ -1100,9 +1073,9 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
         """
         id1, id2 = str(uuid.uuid4()), str(uuid.uuid4())
         with self.g.session_scope():
-            self.g.node_insert(PsqlNode(id1, "test"))
+            self.g.node_insert(psqlgraph.PolyNode(id1, "test"))
             with self.g.session_scope():
-                self.g.node_insert(PsqlNode(id2, "foo"))
+                self.g.node_insert(psqlgraph.PolyNode(id2, "foo"))
             self.assertEqual(self.g.node_lookup(id1).one().label, "test")
             self.assertEqual(self.g.node_lookup(id2).one().label, "foo")
         self.assertFalse(self.g.has_session())
@@ -1116,10 +1089,10 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
         """
         id1, id2 = str(uuid.uuid4()), str(uuid.uuid4())
         with self.g.session_scope() as outer:
-            self.g.node_insert(PsqlNode(id1, "test"))
+            self.g.node_insert(psqlgraph.PolyNode(id1, "test"))
             with self.g.session_scope() as inner:
                 self.assertEqual(inner, outer)
-                self.g.node_insert(PsqlNode(id2, "foo"))
+                self.g.node_insert(psqlgraph.PolyNode(id2, "foo"))
                 inner.rollback()
         with self.g.session_scope():
             self.assertEqual(self.g.node_lookup(id1).count(), 0)
@@ -1136,13 +1109,13 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
         id1, id2, id3 = str(uuid.uuid4()), str(uuid.uuid4()), str(uuid.uuid4())
         outer = self.g._new_session()  # don't do this
         with self.g.session_scope(outer):
-            self.g.node_insert(PsqlNode(id1, "test"))
+            self.g.node_insert(psqlgraph.PolyNode(id1, "test"))
             with self.g.session_scope() as inner:
                 self.assertEqual(inner, outer)
-                self.g.node_insert(PsqlNode(id2, "foo"))
+                self.g.node_insert(psqlgraph.PolyNode(id2, "foo"))
                 with self.g.session_scope() as third:
                     self.assertEqual(third, outer)
-                    self.g.node_insert(PsqlNode(id3, "foo"))
+                    self.g.node_insert(psqlgraph.PolyNode(id3, "foo"))
         with self.g.session_scope():
             self.assertEqual(self.g.node_lookup(id2).count(), 0)
         outer.commit()
@@ -1162,13 +1135,13 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
         id1, id2, id3 = str(uuid.uuid4()), str(uuid.uuid4()), str(uuid.uuid4())
         outer = self.g._new_session()  # don't do this
         with self.g.session_scope(outer):
-            self.g.node_insert(PsqlNode(id1, "test"))
+            self.g.node_insert(psqlgraph.PolyNode(id1, "test"))
             with self.g.session_scope() as inner:
                 self.assertEqual(inner, outer)
-                self.g.node_insert(PsqlNode(id2, "foo"))
+                self.g.node_insert(psqlgraph.PolyNode(id2, "foo"))
                 with self.g.session_scope() as third:
                     self.assertEqual(third, outer)
-                    self.g.node_insert(PsqlNode(id3, "foo"))
+                    self.g.node_insert(psqlgraph.PolyNode(id3, "foo"))
                     third.rollback()
         with self.g.session_scope():
             self.assertEqual(self.g.node_lookup(id1).count(), 0)
@@ -1187,14 +1160,14 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
         id1, id2, id3 = str(uuid.uuid4()), str(uuid.uuid4()), str(uuid.uuid4())
         external = self.g._new_session()
         with self.g.session_scope() as outer:
-            self.g.node_insert(PsqlNode(id1, "foo"))
+            self.g.node_insert(psqlgraph.PolyNode(id1, "foo"))
             with self.g.session_scope(external) as inner:
                 self.assertEqual(inner, external)
                 self.assertNotEqual(inner, outer)
-                self.g.node_insert(PsqlNode(id2, "test"))
+                self.g.node_insert(psqlgraph.PolyNode(id2, "test"))
                 with self.g.session_scope(outer) as third:
                     self.assertEqual(third, outer)
-                    self.g.node_insert(PsqlNode(id3, "foo"))
+                    self.g.node_insert(psqlgraph.PolyNode(id3, "foo"))
                     third.rollback()
         with self.g.session_scope():
             self.assertEqual(self.g.node_lookup(id2).count(), 0)
@@ -1213,8 +1186,8 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
         """
         id1, id2 = str(uuid.uuid4()), str(uuid.uuid4())
         with self.g.session_scope() as session:
-            self.g.node_insert(PsqlNode(id1, "foo"))
-            self.g.node_insert(PsqlNode(id2, "foo"))
+            self.g.node_insert(psqlgraph.PolyNode(id1, "foo"))
+            self.g.node_insert(psqlgraph.PolyNode(id2, "foo"))
             session.rollback()
         with self.g.session_scope():
             self.assertEqual(self.g.node_lookup(id2).count(), 0)
@@ -1225,7 +1198,7 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
         """Test that library functions use the session they're scoped in"""
         id1 = str(uuid.uuid4())
         with self.g.session_scope():
-            self.g.node_insert(PsqlNode(id1, "test"))
+            self.g.node_insert(psqlgraph.PolyNode(id1, "test"))
             self.g.node_lookup(node_id=id1).one()
 
 

--- a/test/test_psqlgraph2.py
+++ b/test/test_psqlgraph2.py
@@ -2,14 +2,13 @@ import logging
 import socket
 import uuid
 
-# We have to import models here, even if we don't use them
-from test import PsqlgraphBaseTest, models
-
 import pytest
-import sqlalchemy as sa
+from sqlalchemy import exc as sa_exc
 
-from psqlgraph import PsqlGraphDriver
-from psqlgraph.exc import SessionClosedError, ValidationError
+import psqlgraph
+import test
+from psqlgraph import exc
+from test import models
 
 log = logging.getLogger(__name__)
 
@@ -18,7 +17,7 @@ def _props(target, updates):
     return models.Test().property_template(updates)
 
 
-class TestPsqlGraphDriver(PsqlgraphBaseTest):
+class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
     def setUp(self):
         self.nid = str(uuid.uuid4())
         self._clear_tables()
@@ -37,7 +36,7 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
         cmd = "select application_name from pg_stat_activity;"
         custom_name = "_CUSTOM_NAME"
 
-        g_ = PsqlGraphDriver(application_name=custom_name, **self.pg_conf)
+        g_ = psqlgraph.PsqlGraphDriver(application_name=custom_name, **self.pg_conf)
         with g_.session_scope() as s:
             s.merge(models.Test("a"))
             app_names = {r[0] for r in self.g.engine.execute(cmd)}
@@ -173,14 +172,14 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
             self.assertEqual(n.foos[0].node_id, "foonode")
 
     def test_type_enum(self):
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(exc.ValidationError):
             models.Foo().fobble = "test"
 
     def test_validate_enum(self):
         n = models.Foo("foonode")
         n.baz = "allowed_1"
         n.baz = "allowed_2"
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(exc.ValidationError):
             n.baz = "not allowed"
 
     def test_association_proxy(self):
@@ -287,7 +286,7 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
         nid = str(uuid.uuid4())
         with self.g.session_scope() as s:
             s.merge(models.Test(nid))
-        with self.assertRaises(sa.exc.OperationalError):
+        with self.assertRaises(sa_exc.OperationalError):
             with self.g.session_scope() as outer:
                 a = outer.query(models.Test).filter(models.Test.node_id == nid).one()
                 with self.g.session_scope(can_inherit=False) as inner:
@@ -319,7 +318,7 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
     def test_session_closing(self):
         with self.g.session_scope():
             nodes = self.g.nodes()
-        with self.assertRaises(SessionClosedError):
+        with self.assertRaises(exc.SessionClosedError):
             nodes.first()
 
     def test_sysan_sanitization(self):

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -1,21 +1,22 @@
 import logging
 import uuid
-from test import PsqlgraphBaseTest, models
 
 import pytest
 
-from psqlgraph import PolyEdge, PolyNode
+import psqlgraph
+import test
+from test import models
 
 logging.basicConfig(level=logging.INFO)
 
 
-class TestPsqlGraphDriver(PsqlgraphBaseTest):
+class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
     def setUp(self):
         self.parent_id = str(uuid.uuid4())
-        self.g.node_insert(PolyNode(self.parent_id, "test"))
+        self.g.node_insert(psqlgraph.PolyNode(self.parent_id, "test"))
         self._create_subtree(self.parent_id)
         self.lone_id = str(uuid.uuid4())
-        self.g.node_insert(PolyNode(self.lone_id, "test"))
+        self.g.node_insert(psqlgraph.PolyNode(self.lone_id, "test"))
 
     def _create_subtree(self, parent_id, level=0):
         for i in range(4):
@@ -23,8 +24,12 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
             foo_id = str(uuid.uuid4())
             self.g.node_merge(node_id=node_id, label="test", properties={"key2": i, "key3": None})
             self.g.node_merge(node_id=foo_id, label="foo", properties={"bar": i})
-            self.g.edge_insert(PolyEdge(src_id=parent_id, dst_id=node_id, label="edge1"))
-            self.g.edge_insert(PolyEdge(src_id=parent_id, dst_id=foo_id, label="test_edge_2"))
+            self.g.edge_insert(
+                psqlgraph.PolyEdge(src_id=parent_id, dst_id=node_id, label="edge1")
+            )
+            self.g.edge_insert(
+                psqlgraph.PolyEdge(src_id=parent_id, dst_id=foo_id, label="test_edge_2")
+            )
             if level < 2:
                 self._create_subtree(node_id, level + 1)
 
@@ -135,7 +140,7 @@ class TestPsqlGraphDriver(PsqlgraphBaseTest):
             )
 
 
-@pytest.mark.parametrize("node_type", [models.Foo, models.Node])
+@pytest.mark.parametrize("node_type", [models.Foo, psqlgraph.Node])
 @pytest.mark.parametrize(
     "col, vals, expected_count",
     [
@@ -152,7 +157,7 @@ def test__props_in__list(pg_driver, samples_with_array, node_type, col, vals, ex
         assert r == expected_count
 
 
-@pytest.mark.parametrize("node_type", [models.Foo, models.Node])
+@pytest.mark.parametrize("node_type", [models.Foo, psqlgraph.Node])
 def test__props_in__int(pg_driver, samples_with_array, node_type):
     with pg_driver.session_scope() as s:
         # fobble is type int

--- a/test/test_traversal.py
+++ b/test/test_traversal.py
@@ -1,9 +1,9 @@
 import uuid
-from test import models
 
 import pytest
 
-from psqlgraph import Edge, Node
+import psqlgraph
+from test import models
 
 
 def no_allowed_2_please(edge):
@@ -18,17 +18,8 @@ def no_allowed_2_please(edge):
 
 
 def clean_tables(pg_driver):
-    conn = pg_driver.engine.connect()
-    conn.execute("commit")
-    for table in Node().get_subclass_table_names():
-        if table != Node.__tablename__:
-            conn.execute(f"delete from {table}")
-    for table in Edge.get_subclass_table_names():
-        if table != Edge.__tablename__:
-            conn.execute(f"delete from {table}")
-    conn.execute("delete from _voided_nodes")
-    conn.execute("delete from _voided_edges")
-    conn.close()
+    psqlgraph.drop_all(pg_driver.engine)
+    psqlgraph.create_all(pg_driver.engine)
 
 
 @pytest.fixture

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,7 +1,7 @@
-from psqlgraph import sanitize
+from psqlgraph import util
 
 
 def test_sanitize():
     props = dict(state="PASSED", versions=["a", "b"])
-    sprops = sanitize(props)
+    sprops = util.sanitize(props)
     assert props["state"] == sprops["state"]


### PR DESCRIPTION
The main goal of these changes is to standardize the psqlgraph package interface & use it in the tests while standardizing their imports w/ the style guide.

Changes for the psqlgraph interface:
- `drop_all` is now included
- Both `AbstractNode` & `AbstractEdge` are exported for better type hinting w/ ext based classes.
- `util.sanitize` & `util.validate` were removed.