### PR TITLE
DEV-3250: Pull PolyEdge & PolyNode into separate module.

### DIFF
--- a/src/psqlgraph/__init__.py
+++ b/src/psqlgraph/__init__.py
@@ -1,7 +1,8 @@
 from psqlgraph.attributes import pg_property
 from psqlgraph.base import create_all, drop_all
-from psqlgraph.edge import AbstractEdge, Edge, PolyEdge
-from psqlgraph.node import AbstractNode, Node, PolyNode
+from psqlgraph.edge import AbstractEdge, Edge
+from psqlgraph.node import AbstractNode, Node
+from psqlgraph.poly import PolyEdge, PolyNode
 from psqlgraph.psql import PsqlGraphDriver
 from psqlgraph.voided import VoidedEdge, VoidedNode
 

--- a/src/psqlgraph/__init__.py
+++ b/src/psqlgraph/__init__.py
@@ -2,7 +2,7 @@ from psqlgraph.attributes import pg_property
 from psqlgraph.base import create_all, drop_all
 from psqlgraph.edge import AbstractEdge, Edge
 from psqlgraph.node import AbstractNode, Node
-from psqlgraph.poly import PolyEdge, PolyNode
+from psqlgraph.poly import PolyEdge, PolyNode, poly_edge, poly_node
 from psqlgraph.psql import PsqlGraphDriver
 from psqlgraph.voided import VoidedEdge, VoidedNode
 
@@ -19,4 +19,6 @@ __all__ = (
     "create_all",
     "drop_all",
     "pg_property",
+    "poly_node",
+    "poly_edge",
 )

--- a/src/psqlgraph/edge.py
+++ b/src/psqlgraph/edge.py
@@ -238,34 +238,5 @@ class Edge(base.LocalConcreteBase, AbstractEdge, base.ORMBase):
     pass
 
 
-def PolyEdge(
-    src_id=None,
-    dst_id=None,
-    label=None,
-    acl=None,
-    system_annotations=None,
-    properties=None,
-):
-    if not label:
-        raise AttributeError("You cannot create a PolyEdge without a label.")
-    try:
-        edge_type_class = Edge.get_subclass(label)
-    except Exception as e:
-        raise RuntimeError(
-            "{}: Unable to determine edge type. If there are more than one "
-            "edges with label {}, you need to specify src_label and dst_label"
-            "using the PsqlGraphDriver.get_PolyEdge())".format(e, label)
-        )
-
-    return edge_type_class(
-        src_id=src_id,
-        dst_id=dst_id,
-        properties=properties or {},
-        acl=acl or [],
-        system_annotations=system_annotations or {},
-        label=label,
-    )
-
-
 # Node and Edge classes depend on each other so this needs to be done down here
 from psqlgraph.node import Node

--- a/src/psqlgraph/node.py
+++ b/src/psqlgraph/node.py
@@ -271,15 +271,3 @@ class AbstractNode(NodeAssociationProxyMixin, base.ExtMixin):
 
 class Node(base.LocalConcreteBase, AbstractNode, base.ORMBase):
     pass
-
-
-def PolyNode(node_id=None, label=None, acl=None, system_annotations=None, properties=None):
-    assert label, "You cannot create a PolyNode without a label."
-    Type = Node.get_subclass(label)
-    return Type(
-        node_id=node_id,
-        properties=properties or {},
-        acl=acl or [],
-        system_annotations=system_annotations or {},
-        label=label,
-    )

--- a/src/psqlgraph/poly.py
+++ b/src/psqlgraph/poly.py
@@ -1,0 +1,52 @@
+"""A module for poly edges/nodes which generate an entity based on a label."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from psqlgraph import edge, node
+
+
+def PolyEdge(
+    *,
+    label: str,
+    src_id: str | None = None,
+    dst_id: str | None = None,
+    acl: list[str] | None = None,
+    system_annotations: Mapping[str, Any] | None = None,
+    properties: Mapping[str, Any] | None = None,
+):
+    edge_cls = edge.Edge.get_subclass(label)
+
+    if not edge_cls:
+        raise ValueError(f"Cannot resolve edge type with label: {label}")
+
+    return edge_cls(
+        src_id=src_id,
+        dst_id=dst_id,
+        properties=properties or {},
+        acl=acl or [],
+        system_annotations=system_annotations or {},
+    )
+
+
+def PolyNode(
+    *,
+    label: str,
+    node_id: str | None = None,
+    acl: list[str] | None = None,
+    system_annotations: Mapping[str, Any] | None = None,
+    properties: Mapping[str, Any] | None = None,
+):
+    node_cls = node.Node.get_subclass(label)
+
+    if not node_cls:
+        raise ValueError(f"Cannot resolve node type with label: {label}")
+
+    return node_cls(
+        node_id=node_id,
+        properties=properties or {},
+        acl=acl or [],
+        system_annotations=system_annotations or {},
+    )

--- a/src/psqlgraph/poly.py
+++ b/src/psqlgraph/poly.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any
 
+from typing_extensions import deprecated
+
 from psqlgraph import edge, node
 
 
-def PolyEdge(
+def poly_edge(
     *,
     label: str,
     src_id: str | None = None,
@@ -16,7 +18,21 @@ def PolyEdge(
     acl: list[str] | None = None,
     system_annotations: Mapping[str, Any] | None = None,
     properties: Mapping[str, Any] | None = None,
-):
+) -> edge.Edge:
+    """Creates an edge with the type represented with the given label.
+
+    Args:
+        label: The label which represents the underlying edge class which should be
+            instantiated.
+        src_id: The ID of the source node for the edge.
+        dst_id: The ID of the destination node for the edge.
+        acl: The acl associated with the edge.
+        system_annotations: Any system annotations which should be set on the new edge.
+        properties: Any properties which should be set on the new edge.
+
+    Returns:
+        A new instance of the edge represented by the given label.
+    """
     edge_cls = edge.Edge.get_subclass(label)
 
     if not edge_cls:
@@ -31,14 +47,48 @@ def PolyEdge(
     )
 
 
-def PolyNode(
+@deprecated("An alias for `psqlgraph.poly_edge`; please call directly.")
+def PolyEdge(
+    *,
+    label: str,
+    src_id: str | None = None,
+    dst_id: str | None = None,
+    acl: list[str] | None = None,
+    system_annotations: Mapping[str, Any] | None = None,
+    properties: Mapping[str, Any] | None = None,
+) -> edge.Edge:
+    return poly_edge(
+        label=label,
+        src_id=src_id,
+        dst_id=dst_id,
+        acl=acl,
+        system_annotations=system_annotations,
+        properties=properties,
+    )
+
+
+def poly_node(
     *,
     label: str,
     node_id: str | None = None,
     acl: list[str] | None = None,
     system_annotations: Mapping[str, Any] | None = None,
     properties: Mapping[str, Any] | None = None,
-):
+) -> node.Node:
+    """Creates an node with the type represented with the given label.
+
+    Args:
+        label: The label which represents the underlying node class which should be
+            instantiated.
+        dst_id: The ID of the new node.
+        acl: The acl associated with the node.
+        system_annotations: Any system annotations which should be set on the new node.
+        properties: Any properties which should be set on the new node.
+
+    Returns:
+        A new instance of the node represented by the given label.
+    """
+
     node_cls = node.Node.get_subclass(label)
 
     if not node_cls:
@@ -49,4 +99,22 @@ def PolyNode(
         properties=properties or {},
         acl=acl or [],
         system_annotations=system_annotations or {},
+    )
+
+
+@deprecated("An alias for `psqlgraph.poly_node`; please call directly.")
+def PolyNode(
+    *,
+    label: str,
+    node_id: str | None = None,
+    acl: list[str] | None = None,
+    system_annotations: Mapping[str, Any] | None = None,
+    properties: Mapping[str, Any] | None = None,
+) -> node.Node:
+    return poly_node(
+        label=label,
+        node_id=node_id,
+        acl=acl,
+        system_annotations=system_annotations,
+        properties=properties,
     )

--- a/src/psqlgraph/psql.py
+++ b/src/psqlgraph/psql.py
@@ -15,11 +15,10 @@ from sqlalchemy.orm import configure_mappers, sessionmaker
 from sqlalchemy.orm.attributes import flag_modified
 from typing_extensions import Literal
 
-from psqlgraph import ext, voided
+from psqlgraph import ext, poly, voided
 from psqlgraph.edge import AbstractEdge
 from psqlgraph.exc import QueryError
 from psqlgraph.hooks import receive_before_flush
-from psqlgraph.poly import PolyNode
 from psqlgraph.query import GraphQuery
 from psqlgraph.session import GraphSession
 
@@ -365,7 +364,7 @@ class PsqlGraphDriver:
                 node = self.nodes(cls).ids([node_id]).scalar()
 
             if not node:
-                node = PolyNode(
+                node = poly.poly_node(
                     node_id=node_id,
                     label=label,
                     acl=acl,

--- a/src/psqlgraph/psql.py
+++ b/src/psqlgraph/psql.py
@@ -19,7 +19,7 @@ from psqlgraph import ext, voided
 from psqlgraph.edge import AbstractEdge
 from psqlgraph.exc import QueryError
 from psqlgraph.hooks import receive_before_flush
-from psqlgraph.node import PolyNode
+from psqlgraph.poly import PolyNode
 from psqlgraph.query import GraphQuery
 from psqlgraph.session import GraphSession
 
@@ -365,7 +365,13 @@ class PsqlGraphDriver:
                 node = self.nodes(cls).ids([node_id]).scalar()
 
             if not node:
-                node = PolyNode(node_id, label, acl, system_annotations, properties)
+                node = PolyNode(
+                    node_id=node_id,
+                    label=label,
+                    acl=acl,
+                    system_annotations=system_annotations,
+                    properties=properties,
+                )
             else:
                 self.node_update(node, system_annotations, acl, properties)
 

--- a/test/test_poly.py
+++ b/test/test_poly.py
@@ -9,7 +9,7 @@ from test import models
 
 
 def test__poly_edge__generates_defaults() -> None:
-    edge = psqlgraph.PolyEdge(label=models.Edge2.get_label())
+    edge = psqlgraph.poly_edge(label=models.Edge2.get_label())
 
     assert edge.src_id is None
     assert edge.dst_id is None
@@ -44,11 +44,11 @@ def test__poly_edge__generates_defaults() -> None:
     ),
 )
 def test__poly_edge__generates_from_input(inputs: dict) -> None:
-    """Given a PolyEdge or PolyNode
+    """Given a poly_edge or poly_node
     When called with an unknown label (i.e. associated with no graph entity.)
     Then a ValueError is raised.
     """
-    edge = psqlgraph.PolyEdge(**inputs)
+    edge = psqlgraph.poly_edge(**inputs)
 
     assert edge.src_id == inputs["src_id"]
     assert edge.dst_id == inputs["dst_id"]
@@ -66,7 +66,7 @@ def test__poly_edge__generates_from_input(inputs: dict) -> None:
 
 
 def test__poly_node__generates_defaults() -> None:
-    node = psqlgraph.PolyNode(label=models.FooBar.get_label())
+    node = psqlgraph.poly_node(label=models.FooBar.get_label())
 
     assert node.node_id is None
     assert node.acl == []
@@ -98,11 +98,11 @@ def test__poly_node__generates_defaults() -> None:
     ),
 )
 def test__poly_node__generates_from_input(inputs: dict) -> None:
-    """Given a PolyEdge or PolyNode
+    """Given a poly_edge or poly_node
     When called with an unknown label (i.e. associated with no graph entity.)
     Then a ValueError is raised.
     """
-    node = psqlgraph.PolyNode(**inputs)
+    node = psqlgraph.poly_node(**inputs)
 
     assert node.node_id == inputs["node_id"]
     assert node.acl == inputs["acl"]
@@ -119,11 +119,19 @@ def test__poly_node__generates_from_input(inputs: dict) -> None:
 
 
 @pytest.mark.parametrize("label", ("mysterious", None))
-@pytest.mark.parametrize("entity", (psqlgraph.PolyEdge, psqlgraph.PolyNode))
+@pytest.mark.parametrize("entity", (psqlgraph.poly_edge, psqlgraph.poly_node))
 def test__poly_entity__unknown_label(entity: Callable, label: str | None) -> None:
-    """Given a PolyEdge or PolyNode
+    """Given a poly_edge or poly_node
     When called with an unknown label (i.e. associated with no graph entity.)
     Then a ValueError is raised.
     """
     with pytest.raises(ValueError):
         entity(label=label)
+
+
+@pytest.mark.parametrize(
+    "entity",
+    (psqlgraph.PolyEdge, psqlgraph.PolyNode),
+)
+def test__poly_entity__deprecation(entity: Callable) -> None:
+    assert getattr(entity, "__deprecated__", False)

--- a/test/test_poly.py
+++ b/test/test_poly.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+
+import psqlgraph
+from test import models
+
+
+def test__poly_edge__generates_defaults() -> None:
+    edge = psqlgraph.PolyEdge(label=models.Edge2.get_label())
+
+    assert edge.src_id is None
+    assert edge.dst_id is None
+    assert edge.acl == []
+    assert edge.system_annotations == {}
+    assert edge.properties == {}
+
+
+@pytest.mark.parametrize(
+    "inputs",
+    (
+        pytest.param(
+            {
+                "label": models.Edge1.get_label(),
+                "src_id": "s0",
+                "dst_id": "d0",
+                "acl": ["open"],
+                "properties": {"key1": "opens a fun door somewhere"},
+            },
+            id="edge-with-properties",
+        ),
+        pytest.param(
+            {
+                "label": models.Edge3.get_label(),
+                "src_id": "n0",
+                "dst_id": "n1",
+                "acl": ["secret"],
+                "system_annotations": {"code": "red"},
+            },
+            id="edge-with-system-annotation",
+        ),
+    ),
+)
+def test__poly_edge__generates_from_input(inputs: dict) -> None:
+    """Given a PolyEdge or PolyNode
+    When called with an unknown label (i.e. associated with no graph entity.)
+    Then a ValueError is raised.
+    """
+    edge = psqlgraph.PolyEdge(**inputs)
+
+    assert edge.src_id == inputs["src_id"]
+    assert edge.dst_id == inputs["dst_id"]
+    assert edge.acl == inputs["acl"]
+
+    if "properties" in inputs:
+        for prop, value in inputs["properties"].items():
+            assert prop in edge.properties
+            assert edge.properties[prop] == value
+
+    if "system_annotations" in inputs:
+        for prop, value in inputs["system_annotations"].items():
+            assert prop in edge.system_annotations
+            assert edge.system_annotations[prop] == value
+
+
+def test__poly_node__generates_defaults() -> None:
+    node = psqlgraph.PolyNode(label=models.FooBar.get_label())
+
+    assert node.node_id is None
+    assert node.acl == []
+    assert node.system_annotations == {}
+    assert node.properties == {"bar": None}
+
+
+@pytest.mark.parametrize(
+    "inputs",
+    (
+        pytest.param(
+            {
+                "label": models.Foo.get_label(),
+                "node_id": "f0",
+                "acl": ["open"],
+                "properties": {"bar": "testing-fun"},
+            },
+            id="node-with-properties",
+        ),
+        pytest.param(
+            {
+                "label": models.Circle1.get_label(),
+                "node_id": "c0",
+                "acl": ["secret"],
+                "system_annotations": {"dummy": "value"},
+            },
+            id="node-with-system-annotation",
+        ),
+    ),
+)
+def test__poly_node__generates_from_input(inputs: dict) -> None:
+    """Given a PolyEdge or PolyNode
+    When called with an unknown label (i.e. associated with no graph entity.)
+    Then a ValueError is raised.
+    """
+    node = psqlgraph.PolyNode(**inputs)
+
+    assert node.node_id == inputs["node_id"]
+    assert node.acl == inputs["acl"]
+
+    if "properties" in inputs:
+        for prop, value in inputs["properties"].items():
+            assert prop in node.properties
+            assert node.properties[prop] == value
+
+    if "system_annotations" in inputs:
+        for prop, value in inputs["system_annotations"].items():
+            assert prop in node.system_annotations
+            assert node.system_annotations[prop] == value
+
+
+@pytest.mark.parametrize("label", ("mysterious", None))
+@pytest.mark.parametrize("entity", (psqlgraph.PolyEdge, psqlgraph.PolyNode))
+def test__poly_entity__unknown_label(entity: Callable, label: str | None) -> None:
+    """Given a PolyEdge or PolyNode
+    When called with an unknown label (i.e. associated with no graph entity.)
+    Then a ValueError is raised.
+    """
+    with pytest.raises(ValueError):
+        entity(label=label)

--- a/test/test_psqlgraph.py
+++ b/test/test_psqlgraph.py
@@ -52,7 +52,7 @@ class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
         Verify the case where a user merges a single non-existent node
         """
         with self.g.session_scope():
-            self.assertRaises(AssertionError, self.g.node_merge, node_id=str(uuid.uuid4()))
+            self.assertRaises(ValueError, self.g.node_merge, node_id=str(uuid.uuid4()))
 
     def test_node_null_query_one(self):
         """Test querying of a single non-existent node
@@ -256,7 +256,7 @@ class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
 
         props = util.sanitize({"key1": None, "key2": 2})
         with self.g.session_scope():
-            node = psqlgraph.PolyNode(node_id, "test", properties=props)
+            node = psqlgraph.PolyNode(node_id=node_id, label="test", properties=props)
         test_string = "This is a test"
         node.properties["key1"] = test_string
         with self.g.session_scope() as session:
@@ -451,7 +451,7 @@ class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
 
         Verify that the library handles null nodes properly on merging
         """
-        self.assertRaises(AssertionError, self.g.node_merge)
+        self.assertRaises(ValueError, self.g.node_merge)
 
     def test_repeated_node_update_properties_by_id(self, given_id=None):
         """Test repeated node updating to properties by ID
@@ -606,20 +606,6 @@ class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
             self.g.node_delete(node_id=node_id)
             with self.g.session_scope():
                 self.assertIs(self.g.node_lookup_one(node_id=node_id), None)
-
-    def test_edge_insert_null_label(self):
-        """Test merging of a null edge
-
-        Verify the case where a user merges a single non-existent node
-        """
-
-        self.assertRaises(
-            AttributeError,
-            psqlgraph.PolyEdge,
-            str(uuid.uuid4()),
-            str(uuid.uuid4),
-            None,
-        )
 
     def test_edge_insert_and_lookup(self):
         """Test edge creation and lookup by dst_id, src_id, dst_id and src_id"""
@@ -970,7 +956,7 @@ class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
     def test_simple_automatic_session(self):
         idA = str(uuid.uuid4())
         with self.g.session_scope():
-            self.g.node_insert(psqlgraph.PolyNode(idA, "test"))
+            self.g.node_insert(psqlgraph.PolyNode(node_id=idA, label="test"))
         with self.g.session_scope():
             self.g.node_lookup(idA).one()
 
@@ -985,8 +971,8 @@ class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
         nid = str(uuid.uuid4())
         with self.assertRaises(exc.IntegrityError):
             with self.g.session_scope():
-                self.g.node_insert(psqlgraph.PolyNode(nid, "test"))
-                self.g.node_insert(psqlgraph.PolyNode(nid, "test"))
+                self.g.node_insert(psqlgraph.PolyNode(node_id=nid, label="test"))
+                self.g.node_insert(psqlgraph.PolyNode(node_id=nid, label="test"))
         with self.g.session_scope():
             self.assertEqual(len(list(self.g.node_lookup(nid).all())), 0)
 
@@ -1000,8 +986,10 @@ class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
 
         """
         nid = str(uuid.uuid4())
-        self.g.node_insert(psqlgraph.PolyNode(nid, "test"))
-        self.assertRaises(exc.IntegrityError, self.g.node_insert, psqlgraph.PolyNode(nid, "test"))
+        self.g.node_insert(psqlgraph.PolyNode(node_id=nid, label="test"))
+        self.assertRaises(
+            exc.IntegrityError, self.g.node_insert, psqlgraph.PolyNode(node_id=nid, label="test")
+        )
         with self.g.session_scope():
             self.assertEqual(self.g.node_lookup(nid).one().label, "test")
         self.assertFalse(self.g.has_session())
@@ -1016,9 +1004,9 @@ class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
         nid = str(uuid.uuid4())
         with self.assertRaises(exc.IntegrityError):
             with self.g.session_scope():
-                self.g.node_insert(psqlgraph.PolyNode(nid, "test"))
+                self.g.node_insert(psqlgraph.PolyNode(node_id=nid, label="test"))
                 with self.g.session_scope(can_inherit=False):
-                    self.g.node_insert(psqlgraph.PolyNode(nid, "test"))
+                    self.g.node_insert(psqlgraph.PolyNode(node_id=nid, label="test"))
         with self.g.session_scope():
             self.assertEqual(self.g.node_lookup(nid).one().label, "test")
         self.assertFalse(self.g.has_session())
@@ -1033,12 +1021,12 @@ class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
         """
         id1 = str(uuid.uuid4())
         id2 = str(uuid.uuid4())
-        self.g.node_insert(psqlgraph.PolyNode(id1, "foo"))
+        self.g.node_insert(psqlgraph.PolyNode(node_id=id1, label="foo"))
         with self.g.session_scope():
-            self.g.node_insert(psqlgraph.PolyNode(id2, "test"))
+            self.g.node_insert(psqlgraph.PolyNode(node_id=id2, label="test"))
             with self.assertRaises(exc.IntegrityError):
                 with self.g.session_scope(can_inherit=False):
-                    self.g.node_insert(psqlgraph.PolyNode(id1, "foo"))
+                    self.g.node_insert(psqlgraph.PolyNode(node_id=id1, label="foo"))
         with self.g.session_scope():
             self.assertEqual(self.g.node_lookup(id2).one().label, "test")
         self.assertFalse(self.g.has_session())
@@ -1052,13 +1040,13 @@ class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
 
         """
         id1, id2, id3 = str(uuid.uuid4()), str(uuid.uuid4()), str(uuid.uuid4())
-        self.g.node_insert(psqlgraph.PolyNode(id1, "foo"))
+        self.g.node_insert(psqlgraph.PolyNode(node_id=id1, label="foo"))
         with self.g.session_scope():
-            self.g.node_insert(psqlgraph.PolyNode(id2, "test"))
+            self.g.node_insert(psqlgraph.PolyNode(node_id=id2, label="test"))
             with self.assertRaises(exc.IntegrityError):
                 with self.g.session_scope(can_inherit=False):
-                    self.g.node_insert(psqlgraph.PolyNode(id1, "foo"))
-                    self.g.node_insert(psqlgraph.PolyNode(id3, "foo"))
+                    self.g.node_insert(psqlgraph.PolyNode(node_id=id1, label="foo"))
+                    self.g.node_insert(psqlgraph.PolyNode(node_id=id3, label="foo"))
         with self.g.session_scope():
             self.assertEqual(self.g.node_lookup(id2).one().label, "test")
             self.assertEqual(self.g.node_lookup(id3).count(), 0)
@@ -1073,9 +1061,9 @@ class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
         """
         id1, id2 = str(uuid.uuid4()), str(uuid.uuid4())
         with self.g.session_scope():
-            self.g.node_insert(psqlgraph.PolyNode(id1, "test"))
+            self.g.node_insert(psqlgraph.PolyNode(node_id=id1, label="test"))
             with self.g.session_scope():
-                self.g.node_insert(psqlgraph.PolyNode(id2, "foo"))
+                self.g.node_insert(psqlgraph.PolyNode(node_id=id2, label="foo"))
             self.assertEqual(self.g.node_lookup(id1).one().label, "test")
             self.assertEqual(self.g.node_lookup(id2).one().label, "foo")
         self.assertFalse(self.g.has_session())
@@ -1089,10 +1077,10 @@ class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
         """
         id1, id2 = str(uuid.uuid4()), str(uuid.uuid4())
         with self.g.session_scope() as outer:
-            self.g.node_insert(psqlgraph.PolyNode(id1, "test"))
+            self.g.node_insert(psqlgraph.PolyNode(node_id=id1, label="test"))
             with self.g.session_scope() as inner:
                 self.assertEqual(inner, outer)
-                self.g.node_insert(psqlgraph.PolyNode(id2, "foo"))
+                self.g.node_insert(psqlgraph.PolyNode(node_id=id2, label="foo"))
                 inner.rollback()
         with self.g.session_scope():
             self.assertEqual(self.g.node_lookup(id1).count(), 0)
@@ -1109,13 +1097,13 @@ class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
         id1, id2, id3 = str(uuid.uuid4()), str(uuid.uuid4()), str(uuid.uuid4())
         outer = self.g._new_session()  # don't do this
         with self.g.session_scope(outer):
-            self.g.node_insert(psqlgraph.PolyNode(id1, "test"))
+            self.g.node_insert(psqlgraph.PolyNode(node_id=id1, label="test"))
             with self.g.session_scope() as inner:
                 self.assertEqual(inner, outer)
-                self.g.node_insert(psqlgraph.PolyNode(id2, "foo"))
+                self.g.node_insert(psqlgraph.PolyNode(node_id=id2, label="foo"))
                 with self.g.session_scope() as third:
                     self.assertEqual(third, outer)
-                    self.g.node_insert(psqlgraph.PolyNode(id3, "foo"))
+                    self.g.node_insert(psqlgraph.PolyNode(node_id=id3, label="foo"))
         with self.g.session_scope():
             self.assertEqual(self.g.node_lookup(id2).count(), 0)
         outer.commit()
@@ -1135,13 +1123,13 @@ class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
         id1, id2, id3 = str(uuid.uuid4()), str(uuid.uuid4()), str(uuid.uuid4())
         outer = self.g._new_session()  # don't do this
         with self.g.session_scope(outer):
-            self.g.node_insert(psqlgraph.PolyNode(id1, "test"))
+            self.g.node_insert(psqlgraph.PolyNode(node_id=id1, label="test"))
             with self.g.session_scope() as inner:
                 self.assertEqual(inner, outer)
-                self.g.node_insert(psqlgraph.PolyNode(id2, "foo"))
+                self.g.node_insert(psqlgraph.PolyNode(node_id=id2, label="foo"))
                 with self.g.session_scope() as third:
                     self.assertEqual(third, outer)
-                    self.g.node_insert(psqlgraph.PolyNode(id3, "foo"))
+                    self.g.node_insert(psqlgraph.PolyNode(node_id=id3, label="foo"))
                     third.rollback()
         with self.g.session_scope():
             self.assertEqual(self.g.node_lookup(id1).count(), 0)
@@ -1160,14 +1148,14 @@ class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
         id1, id2, id3 = str(uuid.uuid4()), str(uuid.uuid4()), str(uuid.uuid4())
         external = self.g._new_session()
         with self.g.session_scope() as outer:
-            self.g.node_insert(psqlgraph.PolyNode(id1, "foo"))
+            self.g.node_insert(psqlgraph.PolyNode(node_id=id1, label="foo"))
             with self.g.session_scope(external) as inner:
                 self.assertEqual(inner, external)
                 self.assertNotEqual(inner, outer)
-                self.g.node_insert(psqlgraph.PolyNode(id2, "test"))
+                self.g.node_insert(psqlgraph.PolyNode(node_id=id2, label="test"))
                 with self.g.session_scope(outer) as third:
                     self.assertEqual(third, outer)
-                    self.g.node_insert(psqlgraph.PolyNode(id3, "foo"))
+                    self.g.node_insert(psqlgraph.PolyNode(node_id=id3, label="foo"))
                     third.rollback()
         with self.g.session_scope():
             self.assertEqual(self.g.node_lookup(id2).count(), 0)
@@ -1186,8 +1174,8 @@ class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
         """
         id1, id2 = str(uuid.uuid4()), str(uuid.uuid4())
         with self.g.session_scope() as session:
-            self.g.node_insert(psqlgraph.PolyNode(id1, "foo"))
-            self.g.node_insert(psqlgraph.PolyNode(id2, "foo"))
+            self.g.node_insert(psqlgraph.PolyNode(node_id=id1, label="foo"))
+            self.g.node_insert(psqlgraph.PolyNode(node_id=id2, label="foo"))
             session.rollback()
         with self.g.session_scope():
             self.assertEqual(self.g.node_lookup(id2).count(), 0)
@@ -1198,7 +1186,7 @@ class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
         """Test that library functions use the session they're scoped in"""
         id1 = str(uuid.uuid4())
         with self.g.session_scope():
-            self.g.node_insert(psqlgraph.PolyNode(id1, "test"))
+            self.g.node_insert(psqlgraph.PolyNode(node_id=id1, label="test"))
             self.g.node_lookup(node_id=id1).one()
 
 

--- a/test/test_psqlgraph.py
+++ b/test/test_psqlgraph.py
@@ -22,12 +22,12 @@ class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
 
     def test_getitem(self):
         """Test that indexing nodes/edges accesses their properties"""
-        node = psqlgraph.PolyNode(node_id=str(uuid.uuid4()), label="foo", properties={"bar": 1})
+        node = psqlgraph.poly_node(node_id=str(uuid.uuid4()), label="foo", properties={"bar": 1})
         self.assertEqual(node["bar"], 1)
 
     def test_setitem(self):
         """Test that indexing nodes/edges accesses their properties"""
-        node = psqlgraph.PolyNode(node_id=str(uuid.uuid4()), label="foo", properties={"bar": 1})
+        node = psqlgraph.poly_node(node_id=str(uuid.uuid4()), label="foo", properties={"bar": 1})
         node["bar"] = 2
         self.assertEqual(node["bar"], 2)
         edge = models.Edge1(src_id=None, dst_id=None)
@@ -37,7 +37,7 @@ class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
     def test_long_ints_roundtrip(self):
         """Test that integers that only fit in 26 bits round trip correctly."""
         with self.g.session_scope():
-            node = psqlgraph.PolyNode(
+            node = psqlgraph.poly_node(
                 node_id=str(uuid.uuid4()),
                 label="foo",
                 properties={"bar": 9223372036854775808},
@@ -256,7 +256,7 @@ class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
 
         props = util.sanitize({"key1": None, "key2": 2})
         with self.g.session_scope():
-            node = psqlgraph.PolyNode(node_id=node_id, label="test", properties=props)
+            node = psqlgraph.poly_node(node_id=node_id, label="test", properties=props)
         test_string = "This is a test"
         node.properties["key1"] = test_string
         with self.g.session_scope() as session:
@@ -329,7 +329,7 @@ class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
 
         dst = self.g.node_merge(node_id=str(uuid.uuid4()), label="test")
         edge1 = self.g.edge_insert(
-            psqlgraph.PolyEdge(src_id=node_id, dst_id=dst.node_id, label="edge1")
+            psqlgraph.poly_edge(src_id=node_id, dst_id=dst.node_id, label="edge1")
         )
 
         with self.g.session_scope():
@@ -404,7 +404,7 @@ class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
 
         dst = self.g.node_merge(node_id=str(uuid.uuid4()), label="test")
         edge1 = self.g.edge_insert(
-            psqlgraph.PolyEdge(src_id=node_id, dst_id=dst.node_id, label="edge1")
+            psqlgraph.poly_edge(src_id=node_id, dst_id=dst.node_id, label="edge1")
         )
 
         with self.g.session_scope():
@@ -437,7 +437,7 @@ class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
 
         propertiesB = {"key1": None, "key2": 2, "key3": timestamp()}
         with self.assertRaises(exc.IntegrityError):
-            bad_node = psqlgraph.PolyNode(
+            bad_node = psqlgraph.poly_node(
                 node_id=tempid,
                 system_annotations={},
                 acl=[],
@@ -616,7 +616,7 @@ class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
             self.g.node_merge(node_id=dst_id, label="test")
 
             edge = self.g.edge_insert(
-                psqlgraph.PolyEdge(src_id=src_id, dst_id=dst_id, label="edge1")
+                psqlgraph.poly_edge(src_id=src_id, dst_id=dst_id, label="edge1")
             )
             self.g.edge_update(edge, properties={"test": None})
             self.g.edge_update(edge, properties={"test": 2})
@@ -644,7 +644,7 @@ class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
             self.g.node_merge(node_id=src_id, label="test")
             self.g.node_merge(node_id=dst_id, label="test")
             edge = self.g.edge_insert(
-                psqlgraph.PolyEdge(src_id=src_id, dst_id=dst_id, label="edge1")
+                psqlgraph.poly_edge(src_id=src_id, dst_id=dst_id, label="edge1")
             )
         with self.g.session_scope():
             self.g.edge_update(edge, properties={"test": 3})
@@ -660,7 +660,7 @@ class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
             self.g.node_merge(node_id=src_id, label="test")
             self.g.node_merge(node_id=dst_id, label="test")
             self.g.edge_insert(
-                psqlgraph.PolyEdge(src_id=src_id, dst_id=dst_id, properties=props, label="edge1")
+                psqlgraph.poly_edge(src_id=src_id, dst_id=dst_id, properties=props, label="edge1")
             )
             edge = self.g.edge_lookup_one(src_id=src_id, dst_id=dst_id)
             self.assertEqual(edge.src_id, src_id)
@@ -683,7 +683,7 @@ class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
             for dst_id in dst_ids:
                 self.g.node_merge(node_id=dst_id, label="test")
                 self.g.edge_insert(
-                    psqlgraph.PolyEdge(src_id=src_id, dst_id=dst_id, label="edge1")
+                    psqlgraph.poly_edge(src_id=src_id, dst_id=dst_id, label="edge1")
                 )
 
             edge_ids = [e.dst_id for e in self.g.edge_lookup(src_id=src_id)]
@@ -699,7 +699,7 @@ class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
         with self.g.session_scope():
             nid1 = self.g.node_merge(node_id=str(uuid.uuid4()), label="test").node_id
             nid2 = self.g.node_merge(node_id=str(uuid.uuid4()), label="test").node_id
-            self.g.edge_insert(psqlgraph.PolyEdge(src_id=nid1, dst_id=nid2, label="edge1"))
+            self.g.edge_insert(psqlgraph.poly_edge(src_id=nid1, dst_id=nid2, label="edge1"))
             self.g.edge_lookup(label="edge1", src_id=nid1, dst_id=nid2).one()
 
     def test_edge_to_json(self):
@@ -711,7 +711,7 @@ class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
             dst = self.g.node_merge(node_id=dst_id, label="test")
 
             edge = self.g.edge_insert(
-                psqlgraph.PolyEdge(src_id=src_id, dst_id=dst_id, label="edge1"), session=session
+                psqlgraph.poly_edge(src_id=src_id, dst_id=dst_id, label="edge1"), session=session
             )
 
             expected_json = {
@@ -771,7 +771,7 @@ class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
             dst = self.g.node_merge(node_id=dst_id, label="test")
 
             edge = self.g.edge_insert(
-                psqlgraph.PolyEdge(src_id=src_id, dst_id=dst_id, label="edge1")
+                psqlgraph.poly_edge(src_id=src_id, dst_id=dst_id, label="edge1")
             )
 
             edge_json = edge.to_json()
@@ -804,7 +804,7 @@ class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
                 for dst_id in dst_ids:
                     node = self.g.node_lookup_one(node_id=dst_id)
                     self.g.edge_insert(
-                        psqlgraph.PolyEdge(src_id=src_id, dst_id=node.node_id, label="edge1"),
+                        psqlgraph.poly_edge(src_id=src_id, dst_id=node.node_id, label="edge1"),
                         session=session,
                     )
 
@@ -830,7 +830,7 @@ class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
             for dst_id in dst_ids:
                 self.g.node_merge(node_id=dst_id, label="test")
                 self.g.edge_insert(
-                    psqlgraph.PolyEdge(src_id=src_id, dst_id=dst_id, label="edge1")
+                    psqlgraph.poly_edge(src_id=src_id, dst_id=dst_id, label="edge1")
                 )
 
             # Verify that the edges there are correct
@@ -888,7 +888,7 @@ class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
                 self.g.node_merge(src_id, label="test")
                 self.g.node_merge(dst_id, label="test")
                 self.g.edge_insert(
-                    psqlgraph.PolyEdge(
+                    psqlgraph.poly_edge(
                         src_id=src_id,
                         dst_id=dst_id,
                         label="edge1",
@@ -914,7 +914,7 @@ class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
                 node_id = str(uuid.uuid4())
                 self.g.node_merge(node_id=node_id, label=f"test")
                 self.g.edge_insert(
-                    psqlgraph.PolyEdge(src_id=parent_id, dst_id=node_id, label="edge1")
+                    psqlgraph.poly_edge(src_id=parent_id, dst_id=node_id, label="edge1")
                 )
                 if level < 2:
                     self._create_subtree(node_id, level + 1)
@@ -942,7 +942,7 @@ class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
             self.g.node_merge(node_id=src_id, label="test")
             self.g.node_merge(node_id=dst_id, label="test")
             self.g.node_merge(node_id=foo_id, label="foo")
-            self.g.edge_insert(psqlgraph.PolyEdge(src_id=src_id, dst_id=dst_id, label="edge1"))
+            self.g.edge_insert(psqlgraph.poly_edge(src_id=src_id, dst_id=dst_id, label="edge1"))
             self.g.edge_insert(models.Edge2(src_id, foo_id))
             s.commit()
             self.assertEqual(len(list(self.g.edge_lookup(src_id=src_id, dst_id=dst_id))), 1)
@@ -956,7 +956,7 @@ class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
     def test_simple_automatic_session(self):
         idA = str(uuid.uuid4())
         with self.g.session_scope():
-            self.g.node_insert(psqlgraph.PolyNode(node_id=idA, label="test"))
+            self.g.node_insert(psqlgraph.poly_node(node_id=idA, label="test"))
         with self.g.session_scope():
             self.g.node_lookup(idA).one()
 
@@ -971,8 +971,8 @@ class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
         nid = str(uuid.uuid4())
         with self.assertRaises(exc.IntegrityError):
             with self.g.session_scope():
-                self.g.node_insert(psqlgraph.PolyNode(node_id=nid, label="test"))
-                self.g.node_insert(psqlgraph.PolyNode(node_id=nid, label="test"))
+                self.g.node_insert(psqlgraph.poly_node(node_id=nid, label="test"))
+                self.g.node_insert(psqlgraph.poly_node(node_id=nid, label="test"))
         with self.g.session_scope():
             self.assertEqual(len(list(self.g.node_lookup(nid).all())), 0)
 
@@ -986,9 +986,9 @@ class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
 
         """
         nid = str(uuid.uuid4())
-        self.g.node_insert(psqlgraph.PolyNode(node_id=nid, label="test"))
+        self.g.node_insert(psqlgraph.poly_node(node_id=nid, label="test"))
         self.assertRaises(
-            exc.IntegrityError, self.g.node_insert, psqlgraph.PolyNode(node_id=nid, label="test")
+            exc.IntegrityError, self.g.node_insert, psqlgraph.poly_node(node_id=nid, label="test")
         )
         with self.g.session_scope():
             self.assertEqual(self.g.node_lookup(nid).one().label, "test")
@@ -1004,9 +1004,9 @@ class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
         nid = str(uuid.uuid4())
         with self.assertRaises(exc.IntegrityError):
             with self.g.session_scope():
-                self.g.node_insert(psqlgraph.PolyNode(node_id=nid, label="test"))
+                self.g.node_insert(psqlgraph.poly_node(node_id=nid, label="test"))
                 with self.g.session_scope(can_inherit=False):
-                    self.g.node_insert(psqlgraph.PolyNode(node_id=nid, label="test"))
+                    self.g.node_insert(psqlgraph.poly_node(node_id=nid, label="test"))
         with self.g.session_scope():
             self.assertEqual(self.g.node_lookup(nid).one().label, "test")
         self.assertFalse(self.g.has_session())
@@ -1021,12 +1021,12 @@ class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
         """
         id1 = str(uuid.uuid4())
         id2 = str(uuid.uuid4())
-        self.g.node_insert(psqlgraph.PolyNode(node_id=id1, label="foo"))
+        self.g.node_insert(psqlgraph.poly_node(node_id=id1, label="foo"))
         with self.g.session_scope():
-            self.g.node_insert(psqlgraph.PolyNode(node_id=id2, label="test"))
+            self.g.node_insert(psqlgraph.poly_node(node_id=id2, label="test"))
             with self.assertRaises(exc.IntegrityError):
                 with self.g.session_scope(can_inherit=False):
-                    self.g.node_insert(psqlgraph.PolyNode(node_id=id1, label="foo"))
+                    self.g.node_insert(psqlgraph.poly_node(node_id=id1, label="foo"))
         with self.g.session_scope():
             self.assertEqual(self.g.node_lookup(id2).one().label, "test")
         self.assertFalse(self.g.has_session())
@@ -1040,13 +1040,13 @@ class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
 
         """
         id1, id2, id3 = str(uuid.uuid4()), str(uuid.uuid4()), str(uuid.uuid4())
-        self.g.node_insert(psqlgraph.PolyNode(node_id=id1, label="foo"))
+        self.g.node_insert(psqlgraph.poly_node(node_id=id1, label="foo"))
         with self.g.session_scope():
-            self.g.node_insert(psqlgraph.PolyNode(node_id=id2, label="test"))
+            self.g.node_insert(psqlgraph.poly_node(node_id=id2, label="test"))
             with self.assertRaises(exc.IntegrityError):
                 with self.g.session_scope(can_inherit=False):
-                    self.g.node_insert(psqlgraph.PolyNode(node_id=id1, label="foo"))
-                    self.g.node_insert(psqlgraph.PolyNode(node_id=id3, label="foo"))
+                    self.g.node_insert(psqlgraph.poly_node(node_id=id1, label="foo"))
+                    self.g.node_insert(psqlgraph.poly_node(node_id=id3, label="foo"))
         with self.g.session_scope():
             self.assertEqual(self.g.node_lookup(id2).one().label, "test")
             self.assertEqual(self.g.node_lookup(id3).count(), 0)
@@ -1061,9 +1061,9 @@ class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
         """
         id1, id2 = str(uuid.uuid4()), str(uuid.uuid4())
         with self.g.session_scope():
-            self.g.node_insert(psqlgraph.PolyNode(node_id=id1, label="test"))
+            self.g.node_insert(psqlgraph.poly_node(node_id=id1, label="test"))
             with self.g.session_scope():
-                self.g.node_insert(psqlgraph.PolyNode(node_id=id2, label="foo"))
+                self.g.node_insert(psqlgraph.poly_node(node_id=id2, label="foo"))
             self.assertEqual(self.g.node_lookup(id1).one().label, "test")
             self.assertEqual(self.g.node_lookup(id2).one().label, "foo")
         self.assertFalse(self.g.has_session())
@@ -1077,10 +1077,10 @@ class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
         """
         id1, id2 = str(uuid.uuid4()), str(uuid.uuid4())
         with self.g.session_scope() as outer:
-            self.g.node_insert(psqlgraph.PolyNode(node_id=id1, label="test"))
+            self.g.node_insert(psqlgraph.poly_node(node_id=id1, label="test"))
             with self.g.session_scope() as inner:
                 self.assertEqual(inner, outer)
-                self.g.node_insert(psqlgraph.PolyNode(node_id=id2, label="foo"))
+                self.g.node_insert(psqlgraph.poly_node(node_id=id2, label="foo"))
                 inner.rollback()
         with self.g.session_scope():
             self.assertEqual(self.g.node_lookup(id1).count(), 0)
@@ -1097,13 +1097,13 @@ class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
         id1, id2, id3 = str(uuid.uuid4()), str(uuid.uuid4()), str(uuid.uuid4())
         outer = self.g._new_session()  # don't do this
         with self.g.session_scope(outer):
-            self.g.node_insert(psqlgraph.PolyNode(node_id=id1, label="test"))
+            self.g.node_insert(psqlgraph.poly_node(node_id=id1, label="test"))
             with self.g.session_scope() as inner:
                 self.assertEqual(inner, outer)
-                self.g.node_insert(psqlgraph.PolyNode(node_id=id2, label="foo"))
+                self.g.node_insert(psqlgraph.poly_node(node_id=id2, label="foo"))
                 with self.g.session_scope() as third:
                     self.assertEqual(third, outer)
-                    self.g.node_insert(psqlgraph.PolyNode(node_id=id3, label="foo"))
+                    self.g.node_insert(psqlgraph.poly_node(node_id=id3, label="foo"))
         with self.g.session_scope():
             self.assertEqual(self.g.node_lookup(id2).count(), 0)
         outer.commit()
@@ -1123,13 +1123,13 @@ class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
         id1, id2, id3 = str(uuid.uuid4()), str(uuid.uuid4()), str(uuid.uuid4())
         outer = self.g._new_session()  # don't do this
         with self.g.session_scope(outer):
-            self.g.node_insert(psqlgraph.PolyNode(node_id=id1, label="test"))
+            self.g.node_insert(psqlgraph.poly_node(node_id=id1, label="test"))
             with self.g.session_scope() as inner:
                 self.assertEqual(inner, outer)
-                self.g.node_insert(psqlgraph.PolyNode(node_id=id2, label="foo"))
+                self.g.node_insert(psqlgraph.poly_node(node_id=id2, label="foo"))
                 with self.g.session_scope() as third:
                     self.assertEqual(third, outer)
-                    self.g.node_insert(psqlgraph.PolyNode(node_id=id3, label="foo"))
+                    self.g.node_insert(psqlgraph.poly_node(node_id=id3, label="foo"))
                     third.rollback()
         with self.g.session_scope():
             self.assertEqual(self.g.node_lookup(id1).count(), 0)
@@ -1148,14 +1148,14 @@ class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
         id1, id2, id3 = str(uuid.uuid4()), str(uuid.uuid4()), str(uuid.uuid4())
         external = self.g._new_session()
         with self.g.session_scope() as outer:
-            self.g.node_insert(psqlgraph.PolyNode(node_id=id1, label="foo"))
+            self.g.node_insert(psqlgraph.poly_node(node_id=id1, label="foo"))
             with self.g.session_scope(external) as inner:
                 self.assertEqual(inner, external)
                 self.assertNotEqual(inner, outer)
-                self.g.node_insert(psqlgraph.PolyNode(node_id=id2, label="test"))
+                self.g.node_insert(psqlgraph.poly_node(node_id=id2, label="test"))
                 with self.g.session_scope(outer) as third:
                     self.assertEqual(third, outer)
-                    self.g.node_insert(psqlgraph.PolyNode(node_id=id3, label="foo"))
+                    self.g.node_insert(psqlgraph.poly_node(node_id=id3, label="foo"))
                     third.rollback()
         with self.g.session_scope():
             self.assertEqual(self.g.node_lookup(id2).count(), 0)
@@ -1174,8 +1174,8 @@ class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
         """
         id1, id2 = str(uuid.uuid4()), str(uuid.uuid4())
         with self.g.session_scope() as session:
-            self.g.node_insert(psqlgraph.PolyNode(node_id=id1, label="foo"))
-            self.g.node_insert(psqlgraph.PolyNode(node_id=id2, label="foo"))
+            self.g.node_insert(psqlgraph.poly_node(node_id=id1, label="foo"))
+            self.g.node_insert(psqlgraph.poly_node(node_id=id2, label="foo"))
             session.rollback()
         with self.g.session_scope():
             self.assertEqual(self.g.node_lookup(id2).count(), 0)
@@ -1186,7 +1186,7 @@ class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
         """Test that library functions use the session they're scoped in"""
         id1 = str(uuid.uuid4())
         with self.g.session_scope():
-            self.g.node_insert(psqlgraph.PolyNode(node_id=id1, label="test"))
+            self.g.node_insert(psqlgraph.poly_node(node_id=id1, label="test"))
             self.g.node_lookup(node_id=id1).one()
 
 

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -13,10 +13,10 @@ logging.basicConfig(level=logging.INFO)
 class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
     def setUp(self):
         self.parent_id = str(uuid.uuid4())
-        self.g.node_insert(psqlgraph.PolyNode(self.parent_id, "test"))
+        self.g.node_insert(psqlgraph.PolyNode(node_id=self.parent_id, label="test"))
         self._create_subtree(self.parent_id)
         self.lone_id = str(uuid.uuid4())
-        self.g.node_insert(psqlgraph.PolyNode(self.lone_id, "test"))
+        self.g.node_insert(psqlgraph.PolyNode(node_id=self.lone_id, label="test"))
 
     def _create_subtree(self, parent_id, level=0):
         for i in range(4):

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -13,10 +13,10 @@ logging.basicConfig(level=logging.INFO)
 class TestPsqlGraphDriver(test.PsqlgraphBaseTest):
     def setUp(self):
         self.parent_id = str(uuid.uuid4())
-        self.g.node_insert(psqlgraph.PolyNode(node_id=self.parent_id, label="test"))
+        self.g.node_insert(psqlgraph.poly_node(node_id=self.parent_id, label="test"))
         self._create_subtree(self.parent_id)
         self.lone_id = str(uuid.uuid4())
-        self.g.node_insert(psqlgraph.PolyNode(node_id=self.lone_id, label="test"))
+        self.g.node_insert(psqlgraph.poly_node(node_id=self.lone_id, label="test"))
 
     def _create_subtree(self, parent_id, level=0):
         for i in range(4):


### PR DESCRIPTION
This separates the logic of generating edges and nodes from unique labels into a poly module. Further, it cleans up the interface by making it explicit that `label` is a required input. This will cause some issue when updating downstream repos (zugs). However, in the vast majority of cases (which externally there are only a handful) this is already primarily used with kwargs already; so no changes will be required.